### PR TITLE
Fix dropdown CSS for chromium based browsers

### DIFF
--- a/source/ui/styles/forms.scss
+++ b/source/ui/styles/forms.scss
@@ -233,7 +233,6 @@
     border: 0 !important; 
     width: 100%;
     padding: 5px;
-    background: none;
     border: none;
     color: inherit;
     background: var(--color-section);
@@ -242,6 +241,7 @@
       -webkit-appearance: none;
       -moz-appearance: none;
       appearance: none;
+      background-color: var(--color-section);
     }
 
     @at-root .list-table &{


### PR DESCRIPTION
## Issue
In chromium based browsers, drop-down menus were white on white.
![image](https://github.com/user-attachments/assets/5f3243c3-34b2-4c91-88e9-c359b7ac98b8)

## Solution
This ensures that the background color of option is darker.
![image](https://github.com/user-attachments/assets/b93fdf64-cece-49b7-b9e3-ded94a97fbfc)
