### PR TITLE
Fix the login form keyboard behavior where entering would reveal pwd

### DIFF
--- a/source/server/templates/login.hbs
+++ b/source/server/templates/login.hbs
@@ -29,7 +29,7 @@
               <input type="password" autocomplete="current-password" name="password" id="password" required=""
                 placeholder="{{i18n "labels.password"}}">
               <label for="password">{{i18n "labels.password"}}</label>
-              <button id="password-toggle" aria-checked="false" role="switch" style="display:none" class="btn btn-transparent btn-addon" title="{{i18n "tooltips.showPassword"}}"><ui-icon name="eye"></ui-icon></button>
+              <button id="password-toggle" type="button" aria-checked="false" role="switch" style="display:none" class="btn btn-transparent btn-addon" title="{{i18n "tooltips.showPassword"}}"><ui-icon name="eye"></ui-icon></button>
               <script>
                 (function registerPasswordVisibilityToggle(){
                   const btn = document.querySelector("#password-toggle");
@@ -42,7 +42,7 @@
                     input.type = checked? "text" : "password";
                     btn.ariaChecked = checked.toString();
                   }
-                  btn.style.removeProperty("display");
+                  btn.style.removeProperty("display");             
                 })();
               </script>
             </div>


### PR DESCRIPTION
This was due to the toggle visibility button not having a type. Default button type is submit.
Default behavior when pressing enter/return is to click/trigger the closest submit button. By adding the "button" type, the toggle visibility button is ignored when pressing enter in the form fields.