### PR TITLE
Add an e2e test for the behavior of annotations in a secondary language

### DIFF
--- a/source/e2e/tests/edition.spec.ts
+++ b/source/e2e/tests/edition.spec.ts
@@ -55,6 +55,32 @@ test("can create an annotation", async ()=>{
   await expect(scenePage.getByRole("button", {name: "FR", exact: true})).toBeVisible();
 });
 
+test("can create an annotation in a secondary language", async ()=>{
+  await scenePage.getByRole("button", {name: "Annotations"}).click();
+  await scenePage.locator(".sv-task-view sv-property-options").filter({hasText: 'Language'}).getByRole("combobox").selectOption("1")// 1 is Spanish
+  await expect(scenePage.getByRole("button", {name: "ES", exact: true})).toBeVisible();
+  const vp = scenePage.viewportSize();
+  
+  
+  await scenePage.mouse.click( vp!.width/1.1,  vp!.height/1.75); // click outside to deselect previous annotation before creating a new one
+  await scenePage.getByRole('button', { name: 'Create' }).click();
+  await scenePage.mouse.click( vp!.width/1.75,  vp!.height/2);
+  await expect(scenePage.getByLabel('annotation', { exact: true })).toHaveCount(2);
+
+  // Modify the default text
+  await scenePage.locator('sv-property-string').filter({ hasText: 'Title' }).getByRole('textbox').fill("Spanish annotation");
+  await scenePage.locator('sv-property-string').filter({ hasText: 'Title' }).getByRole('textbox').press("Enter");
+
+  //Annotation is set and still in spanish
+  await expect(scenePage.getByLabel('annotation', { exact: true }).filter({hasText:"Spanish annotation"})).toBeVisible();
+  await expect(scenePage.getByRole("button", {name: "ES", exact: true})).toBeVisible();
+
+  // Select French again, check that "Spanish annotation" is no longer there
+  await scenePage.locator(".sv-task-view sv-property-options").filter({hasText: 'Language'}).getByRole("combobox").selectOption("5")// 5 is French
+  await expect(scenePage.getByLabel('annotation', { exact: true }).filter({hasText:"Spanish annotation"})).toHaveCount(0);
+  
+});
+
 test("can create an article", async ()=>{
   await scenePage.getByRole("button", {name: "Articles"}).click();
 
@@ -80,7 +106,6 @@ test("can save the scene", async ()=>{
   await scenePage.locator(".sv-task-view").getByRole("combobox").selectOption("5")// 5 is French
   let mce = scenePage.locator('sv-article-editor').getByRole('application').locator("iframe").contentFrame();
   await expect(mce.getByRole("heading")).toHaveText("Nouvel Article");
-
   // Interface is still in english even if active language is in french. See rc-53
   //This locator should target role = "navigation" when this gets implemented
   await scenePage.locator("sv-task-bar").getByRole('button', { name: 'Save' }).click();


### PR DESCRIPTION
This covers the regression fixed in https://github.com/Holusion/dpo-voyager/pull/1