### PR TITLE
apply styles to email templates

### DIFF
--- a/source/server/routes/admin/index.ts
+++ b/source/server/routes/admin/index.ts
@@ -4,9 +4,10 @@ import { Router } from "express";
 import { isAdministrator } from "../../utils/locals.js";
 import wrap from "../../utils/wrapAsync.js";
 import handleGetStats from "./stats/index.js";
-import handleMailtest from "./mailtest.js";
+import handleMailtest from "./mail/sendtest.js";
 import handleGetConfig from "./config/get.js";
 import bodyParser from "body-parser";
+import handleRenderMail from "./mail/render.js";
 
 
 const router = Router();
@@ -24,6 +25,8 @@ router.use((req, res, next)=>{
 
 router.get("/stats", isAdministrator, wrap(handleGetStats));
 router.get("/config", isAdministrator, wrap(handleGetConfig));
-router.post("/mailtest", isAdministrator, bodyParser.json(), wrap(handleMailtest));
+
+router.post("/mail/test", isAdministrator, bodyParser.json(), wrap(handleMailtest));
+router.get("/mail/render/:name", isAdministrator, bodyParser.json(), wrap(handleRenderMail));
 
 export default router;

--- a/source/server/routes/admin/mail/render.ts
+++ b/source/server/routes/admin/mail/render.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from "express";
+import sendmail from "../../../utils/mails/send.js";
+import { getLocals, getUser } from "../../../utils/locals.js";
+import { BadRequestError } from "../../../utils/errors.js";
+import { useTemplateProperties } from "../../views/index.js";
+
+/**
+ * Send a test email
+ * Exposes all possible logs from the emailer
+ * This is a protected route and requires admin privileges
+ */
+export default async function handleRenderMail(req :Request, res :Response){
+  const {name} = req.params;
+  const {config} = getLocals(req);
+  let {username} = req.query
+  const {username:requester, email} = getUser(req) ?? {};
+  if(typeof username !== "string" || !username.length){
+    username = requester;
+  }
+
+  useTemplateProperties(req, res);
+  const mail_content = await getLocals(req).templates.render(`emails/${name}`, {
+    layout: null,
+    brand: config.brand,
+    hostname: config.hostname,
+    name: username,
+    url: "http://example.com/foo",
+  });
+
+  res.status(200).set("Content-Type", "text/html; encoding=utf-8").send(`<!DOCTYPE html><html>
+    <head>
+      <style type="text/css">
+        html, body{
+          color-scheme: light dark;
+          background-color: light-dark(#eeeeee, #333333);
+          pointer-events: none;
+        }
+      </style>
+    </head>
+    <body>${mail_content}</body>
+  </html>`);
+}

--- a/source/server/routes/admin/mail/sendtest.ts
+++ b/source/server/routes/admin/mail/sendtest.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from "express";
-import sendmail from "../../utils/mails/send.js";
-import { getLocals, getUser } from "../../utils/locals.js";
-import { BadRequestError } from "../../utils/errors.js";
-import { useTemplateProperties } from "../views/index.js";
+import sendmail from "../../../utils/mails/send.js";
+import { getLocals, getUser } from "../../../utils/locals.js";
+import { BadRequestError } from "../../../utils/errors.js";
+import { useTemplateProperties } from "../../views/index.js";
 
 /**
  * Send a test email

--- a/source/server/templates/admin/home.hbs
+++ b/source/server/templates/admin/home.hbs
@@ -11,4 +11,61 @@
       </div>
     </form>
   </submit-fragment>
+  <h4>{{i18n "titles.previewEmail"}}</h4>
+  <form id="preview-email-form" class="form-control" autocomplete="off">
+    <div class="form-group inline">
+      <div class="form-item">
+        <label>Username</label>
+        <input name="username" placeholder="recipient username" value="{{user.username}}">
+      </div>
+      <div class="form-item" >
+        <label>Template</label>
+        <select name="name">
+          {{> inputs/option selected=(test "fr" "==" @root.lang) value="connection_fr" text="connection_fr"}}
+          {{> inputs/option selected=(test "en" "==" @root.lang) value="connection_en" text="connection_en"}}
+          {{> inputs/option selected=(test "en" "==" @root.lang) value="test" text="test"}}
+          
+        </select>
+      </div>
+      <div class="form-item" >
+        <label>Theme</label>
+        <select name="colorScheme">
+          <option selected value="light">Light</option>
+          <option value="dark"> Dark</option>
+        </select>
+      </div>
+      <button role="submit" class="btn">Fetch</button>
+    </div>
+  </form>
+  <script type="module">
+    const f = document.querySelector("#preview-email-form");
+    if(!f) console.error("Couldn't find email preview form");
+
+
+    function onSubmitPreviewEmail(ev){
+      ev.preventDefault();
+      let data = new FormData(ev.target);
+
+      const box = document.createElement("dialog");
+      Object.assign(box.style, {
+        maxWidth: "428px",
+        width: `min(80vw, 428px)`,
+        height: "60vh",
+        colorScheme: `only ${data.get("colorScheme")}`,
+      });
+      box.onmousedown= function(){ event.target==this && this.close()};
+      box.onclose = function(){
+        box.parentElement.removeChild(box);
+      }
+      
+      console.log("Name: ", ev.target)
+      box.innerHTML = `<iframe allowTransparency="true" style="width:100%; height: calc(100% - 10px); border: 0px" src="/admin/mail/render/${data.get("name")}?username=${data.get("username")}"></iframe>`;
+      f.insertAdjacentElement('afterend', box);
+      box.showModal();
+      
+      return false;
+    }
+
+    f.addEventListener("submit", onSubmitPreviewEmail);
+  </script>
 </div>

--- a/source/server/templates/emails/connection_en.hbs
+++ b/source/server/templates/emails/connection_en.hbs
@@ -1,22 +1,17 @@
 
-<h1>eCorpus - connection link</h1>
+<h1 style="display: inline-block; padding: 1.5rem 0.2rem 0 1.5rem; border-bottom: 0.6rem solid #E6B900;">eCorpus - connection link</h1>
 <p>Hi <b>{{name}}</b>,</p>
 <p>Click the link below to connect automatically:</p>
-<p align="center">
-  <a class="btn" href="{{url}}">Login</a>
+
+<p style="text-align: center; padding: 1rem;">
+  <a style="color: white; background: #E6B900; border-radius: 2px; padding: 1rem 1.5rem; font-size: large; text-decoration: none!important;" href="{{url}}">Login</a>
 </p>
+
 <p>This link stays valid for 30 days. If it doesn't work, paste this in your browser address bar:</p>
+
 <p><a href="{{url}}">{{url}}</a></p>
+
 <p>You might want to change your password in user settings to be able to reconnect in the future</p>
 <p>Have a great day!</p>
 
-<style>
-  .btn{
-    color: white;
-    background: #E6B900;
-    display: block;
-    padding: .75rem;
-    font-size:large;
-    text-decoration: none!important;
-  }
-</style>
+

--- a/source/server/templates/emails/connection_fr.hbs
+++ b/source/server/templates/emails/connection_fr.hbs
@@ -1,12 +1,12 @@
 
-<h1>eCorpus - lien de connexion</h1>
+<h1 style="display: inline-block; padding: 1.5rem 0.2rem 0 1.5rem; border-bottom: 0.6rem solid #E6B900;">eCorpus - lien de connexion</h1>
 <p>Bonjour <b>{{name}}</b>,</p>
 <p>
   Nous venons de recevoir une demande de lien de connexion pour un compte lié à votre adresse.<br>
   Connectez-vous en cliquant sur le bouton ci-dessous:
 </p>
-<p align="center">
-  <a class="btn" href="{{url}}">Connectez-vous</a>
+<p style="text-align: center; padding: 1rem;">
+  <a style="color: white; background: #E6B900; border-radius: 2px; padding: 1rem 1.5rem; font-size: large; text-decoration: none!important;" href="{{url}}">Connectez-vous</a>
 </p>
 <p>
   Une fois connecté, n'oubliez pas de réinitialiser votre mot de passe!
@@ -21,13 +21,3 @@
   Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet email.<br>
   Pour rapporter toute erreur, veuillez contacter votre administrateur eCorpus.</a>
 </p>
-<style>
-  .btn{
-    color: white;
-    background: #E6B900;
-    display: block;
-    padding: .75rem;
-    font-size:large;
-    text-decoration: none!important;
-  }
-</style>

--- a/source/server/templates/emails/test.hbs
+++ b/source/server/templates/emails/test.hbs
@@ -1,4 +1,6 @@
-<h1>{{i18n "titles.testEmail" what=brand }}</h1>
+<h1 style="display: inline-block; padding: 1.5rem 0.2rem 0 1.5rem; border-bottom: 0.6rem solid #E6B900;">{{i18n "titles.testEmail" what=brand }}</h1>
+
 <p>{{{i18n "leads.testEmail" hostname=hostname}}}</p>
-<h2>{{i18n "titles.testEmailVerify"}}</h2>
+
+<h2 style="border-left: 0.7rem solid #E6B900; padding: 0.5rem 0 0 0.8rem;">{{i18n "titles.testEmailVerify"}}</h2>
 <p>{{{i18n "leads.testEmailDKIM"}}}</p>

--- a/source/server/templates/locales/en.yml
+++ b/source/server/templates/locales/en.yml
@@ -129,6 +129,7 @@ titles:
   filesStatistics: Data statistics
   modifiedToday: Scenes modified today
   buildRef: Current version
+  previewEmail: Preview email templates
 
 tooltips:
   showPassword: Show the password's text

--- a/source/server/templates/locales/fr.yml
+++ b/source/server/templates/locales/fr.yml
@@ -129,6 +129,7 @@ titles:
   filesStatistics: Données
   modifiedToday: Scènes modifiées aujourd'hui
   buildRef: Version actuelle
+  previewEmail: Voir les templates d'emails
 
 tooltips:
   showPassword: Montrer le texte du mot de passe


### PR DESCRIPTION
fix #109
email styles have to be inlined or they will be sanitized by most providers.

Provide an API route to preview emails