### PR TITLE
time-travel scene view implementation

### DIFF
--- a/source/server/routes/history/diff/get.test.ts
+++ b/source/server/routes/history/diff/get.test.ts
@@ -34,6 +34,7 @@ describe("GET /history/:scene/:id/diff", function(){
     await vfs.writeFile(dataStream(["Hello\n"]), {scene:scene_id, name:"hello.txt", user_id: 0, mime: "text/plain"});
     let ref = await vfs.writeFile(dataStream(["Hello World\n"]), {scene:scene_id, name:"hello.txt", user_id: 0, mime: "text/plain"});
     let res = await request(this.server).get(`/history/foo/${ref.id}/diff`)
+    .auth(user.username, "12345678")
     .set("Accept", "text/plain")
     .expect(200)
     .expect("Content-Type", "text/plain; charset=utf-8");
@@ -44,6 +45,7 @@ describe("GET /history/:scene/:id/diff", function(){
       await vfs.writeDoc(`{"label":"foo"}`, {scene: scene_id, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json", user_id: 0});
       let ref = await vfs.writeDoc(`{"label":"bar"}`, {scene: scene_id, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json", user_id: 0});
       let res = await request(this.server).get(`/history/foo/${ref.id}/diff`)
+    .auth(user.username, "12345678")
       .set("Accept", "application/json")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
@@ -58,6 +60,7 @@ describe("GET /history/:scene/:id/diff", function(){
       await vfs.writeDoc(docString, {scene: scene_id, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json", user_id: 0});
       let ref = await vfs.writeDoc(JSON.stringify(doc2), {scene: scene_id, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json", user_id: 0});
       let res = await request(this.server).get(`/history/foo/${ref.id}/diff`)
+      .auth(user.username, "12345678")
       .set("Accept", "application/json")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");

--- a/source/server/routes/history/get.test.ts
+++ b/source/server/routes/history/get.test.ts
@@ -45,6 +45,7 @@ describe("GET /history/:scene", function(){
 
     it("get a scene's history", async function(){
       let res = await request(this.server).get("/history/foo")
+      .auth(user.username, "12345678")
       .set("Accept", "application/json")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
@@ -61,6 +62,7 @@ describe("GET /history/:scene", function(){
 
     it("get text history", async function(){
       let res = await request(this.server).get("/history/foo")
+      .auth(user.username, "12345678")
       .set("Accept", "text/plain")
       .expect(200)
       .expect("Content-Type", "text/plain; charset=utf-8");
@@ -70,11 +72,13 @@ describe("GET /history/:scene", function(){
     it("get an empty history", async function(){
       await vfs.createScene("empty", user.uid);
       let res = await request(this.server).get("/history/empty")
+      .auth(user.username, "12345678")
       .expect(200);
     });
 
     it("can ?limit results", async function(){
       let res = await request(this.server).get("/history/foo?limit=1")
+      .auth(user.username, "12345678")
       .set("Accept", "application/json")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
@@ -86,6 +90,7 @@ describe("GET /history/:scene", function(){
 
     it("can ?offset results", async function(){
       let res = await request(this.server).get("/history/foo?limit=1&offset=1")
+      .auth(user.username, "12345678")
       .set("Accept", "application/json")
       .expect(200)
       .expect("Content-Type", "application/json; charset=utf-8");
@@ -95,11 +100,11 @@ describe("GET /history/:scene", function(){
       ]);
     });
 
-    describe("requires read access", function(){
+    describe("requires write access", function(){
       this.beforeAll(async function(){
         await vfs.createScene("private", user.uid);
-        await userManager.setPublicAccess("private", "none");
-        await userManager.setDefaultAccess("private", "none");
+        await userManager.setPublicAccess("private", "read");
+        await userManager.setDefaultAccess("private", "read");
       });
       it("(anonymous)", async function(){
         await request(this.server).get("/history/private")

--- a/source/server/routes/history/index.ts
+++ b/source/server/routes/history/index.ts
@@ -9,6 +9,7 @@ import bodyParser from "body-parser";
 import { postSceneHistory } from "./post.js";
 import getSceneHistory from "./get.js";
 import handleGetDiff from "./diff/get.js";
+import { handleShowFile } from "./show/get.js";
 
 const router = Router();
 
@@ -28,5 +29,7 @@ router.post("/:scene", canAdmin, bodyParser.json(), wrap(postSceneHistory));
 
 router.get("/:scene/:id/diff", wrap(handleGetDiff));
 router.get("/:scene/:id/diff/:from", wrap(handleGetDiff));
+
+router.get("/:scene/:id/show/:name(*)", wrap(handleShowFile));
 
 export default router;

--- a/source/server/routes/history/index.ts
+++ b/source/server/routes/history/index.ts
@@ -1,6 +1,6 @@
 
 import { Router } from "express";
-import { canAdmin, canRead } from "../../utils/locals.js";
+import { canAdmin, canRead, canWrite } from "../../utils/locals.js";
 import wrap from "../../utils/wrapAsync.js";
 
 import bodyParser from "body-parser";
@@ -22,7 +22,7 @@ router.use((req, res, next)=>{
   next();
 });
 
-router.use("/:scene", canRead);
+router.use("/:scene", canWrite);
 
 router.get("/:scene", wrap(getSceneHistory));
 router.post("/:scene", canAdmin, bodyParser.json(), wrap(postSceneHistory));

--- a/source/server/routes/history/show/get.ts
+++ b/source/server/routes/history/show/get.ts
@@ -1,0 +1,37 @@
+import { Request, Response } from "express";
+import { getVfs } from "../../../utils/locals.js";
+import { BadRequestError, NotFoundError } from "../../../utils/errors.js";
+import { pipeline } from "stream/promises";
+import { Readable } from "stream";
+
+
+
+export async function handleShowFile(req: Request, res: Response){
+  let vfs = getVfs(req);
+  let {scene: sceneName, id, name} = req.params;
+  let scene = await vfs.getScene(sceneName);
+  let file = await vfs.getFileBefore({scene: scene.id, name, before: parseInt(id)});
+  if(!file.hash && !file.data) throw new NotFoundError(`${sceneName}/${ name } does not exist at this reference point`);
+  if(file.hash === "directory") throw new BadRequestError(`${sceneName}/${name} appears to be a directory`);
+  let rs = file.data? Readable.from([Buffer.from(file.data)]): (await vfs.openFile({hash: file.hash!})).createReadStream({ });
+  
+  res.set("Content-Length", file.size.toString(10));
+  res.set("Accept-Ranges", "bytes");
+
+  res.set("ETag", `W/${file.hash}`);
+  res.set("Last-Modified", file.mtime.toUTCString());
+  if(req.fresh){
+    rs.destroy();
+    return res.status(304).send("Not Modified");
+  }
+  res.set("Content-Type", file.mime);
+  res.status(200);
+  try{
+    await pipeline(
+      rs,
+      res,
+    );
+  }catch(e){
+    if((e as any).code != "ERR_STREAM_PREMATURE_CLOSE") throw e;
+  }
+}

--- a/source/server/routes/views/index.ts
+++ b/source/server/routes/views/index.ts
@@ -394,7 +394,7 @@ routes.get("/scenes/:scene/edit", canWrite, (req, res)=>{
   });
 });
 
-routes.get("/scenes/:scene/history", canAdmin, wrap(async (req, res)=>{
+routes.get("/scenes/:scene/history", canWrite, wrap(async (req, res)=>{
   let vfs = getVfs(req);
   //scene_name is actually already validated through canAdmin
   let {scene:scene_name} = req.params;
@@ -403,10 +403,11 @@ routes.get("/scenes/:scene/history", canAdmin, wrap(async (req, res)=>{
   res.render("history", {
     title: `eCorpus: History of ${scene_name}`,
     name: scene_name,
-  })
+    canAdmin: res.locals.access === "admin",
+  });
 }))
 
-routes.get("/scenes/:scene/history/:id/view", canAdmin, wrap(async (req, res)=>{
+routes.get("/scenes/:scene/history/:id/view", canWrite, wrap(async (req, res)=>{
   let vfs = getVfs(req);
   //scene_name is actually already validated through canAdmin
   let {scene:scene_name, id} = req.params;

--- a/source/server/routes/views/index.ts
+++ b/source/server/routes/views/index.ts
@@ -406,6 +406,23 @@ routes.get("/scenes/:scene/history", canAdmin, wrap(async (req, res)=>{
   })
 }))
 
+routes.get("/scenes/:scene/history/:id/view", canAdmin, wrap(async (req, res)=>{
+  let vfs = getVfs(req);
+  //scene_name is actually already validated through canAdmin
+  let {scene:scene_name, id} = req.params;
+  let scene = await vfs.getScene(scene_name);
+  let thumb = new URL(`/scenes/${encodeURIComponent(scene_name)}/scene-image-thumb.jpg`, getHost(req));
+  
+  res.render("explorer", {
+    title: `eCorpus: History of ${scene_name}`,
+    layout: "viewer",
+    scene: scene_name,
+    thumb: thumb.toString(),
+    referrer: `/ui/scenes/${scene.name}/history`,
+    scenePath: `/history/${encodeURIComponent(scene.name)}/${encodeURIComponent(id)}/show/`,
+  })
+}));
+
 routes.get("/standalone", (req, res)=>{
   let host = getHost(req);
   let referrer = new URL(req.get("Referrer")||`/ui/scenes/`, host);

--- a/source/server/templates/explorer.hbs
+++ b/source/server/templates/explorer.hbs
@@ -1,5 +1,5 @@
 
-<voyager-explorer resourceroot="/dist/" dracoRoot="/dist/js/draco/" root="/scenes/{{scene}}/" referrer="{{referrer}}"></voyager-explorer>
+<voyager-explorer resourceroot="/dist/" dracoRoot="/dist/js/draco/" root="{{#if scenePath}}{{scenePath}}{{else}}/scenes/{{scene}}/{{/if}}" referrer="{{referrer}}"></voyager-explorer>
 <script type="text/javascript" src="/dist/js/voyager-explorer.js"></script>
 {{#if script }}<script type="text/javascript">
   {{{script}}}

--- a/source/server/templates/history.hbs
+++ b/source/server/templates/history.hbs
@@ -3,5 +3,5 @@
 <div class="section">
   <h2><a href="/ui/scenes/{{encodeURIComponent name}}">{{name}}</a></h2>
   <p>{{{i18n "leads.historyEdition"}}}</p>
-  <scene-history name="{{name}}"></scene-history>
+  <scene-history name="{{name}}" {{#if canAdmin}}write{{/if}}></scene-history>
 </div>

--- a/source/server/vfs/Files.ts
+++ b/source/server/vfs/Files.ts
@@ -187,6 +187,22 @@ export default abstract class FilesVfs extends BaseVfs{
     });
   }
 
+
+  static _fragFileProps({table="files", withData}: {table: string, withData:boolean}){
+    return `${table}.file_id AS id,
+      ${table}.name AS name,
+      ${table}.size AS size,
+      ${table}.hash AS hash,
+      ${withData? "data,":""}
+      ${table}.generation AS generation,
+      (SELECT ctime FROM files AS allFiles WHERE (allFiles.fk_scene_id = ${table}.fk_scene_id AND allFiles.name = ${table}.name AND allFiles.generation = 1)) AS ctime,
+      ${table}.ctime AS mtime,
+      ${table}.mime AS mime,
+      ${table}.fk_author_id AS author_id,
+      COALESCE((SELECT username FROM users WHERE  user_id = ${table}.fk_author_id LIMIT 1), 'default') AS author
+    `;
+  }
+
   async getFileById(id :number) :Promise<FileProps&{scene_id:number}>{
     let r = await this.db.get<{
       id: number,
@@ -203,43 +219,15 @@ export default abstract class FilesVfs extends BaseVfs{
       scene_id: number,
     }>(`
       SELECT
-        file_id AS id,
-        files.name AS name,
-        mime,
-        size,
-        data,
-        hash,
-        generation,
-        first.ctime AS ctime,
-        files.ctime AS mtime,
-        files.fk_author_id AS author_id,
-        COALESCE(username, 'default') AS author,
-        fk_scene_id AS scene_id
-      FROM files 
-        LEFT JOIN (SELECT MIN(ctime) AS ctime, fk_scene_id, name FROM files GROUP BY fk_scene_id, name ) AS first
-          USING(fk_scene_id, name)
-        LEFT JOIN users ON files.fk_author_id = user_id
+        fk_scene_id AS scene_id,
+        ${FilesVfs._fragFileProps({table: "files", withData: true})}
+      FROM files
       WHERE file_id = $1
     `, [ id ]);
     if(!r || !r.ctime) throw new NotFoundError(`No file found with id : ${id}`);
     return r;
   }
 
-
-  static _fragFileProps({table="files", nameIndex, withData}: {table: string, nameIndex:number, withData:boolean}){
-    return `${table}.file_id AS id,
-      ${table}.name AS name,
-      ${table}.size AS size,
-      ${table}.hash AS hash,
-      ${withData? "data,":""}
-      ${table}.generation AS generation,
-      (SELECT ctime FROM files AS allFiles WHERE (allFiles.fk_scene_id = ${table}.fk_scene_id AND allFiles.name = $${nameIndex} AND allFiles.generation = 1)) AS ctime,
-      ${table}.ctime AS mtime,
-      ${table}.mime AS mime,
-      ${table}.fk_author_id AS author_id,
-      COALESCE((SELECT username FROM users WHERE  user_id = ${table}.fk_author_id LIMIT 1), 'default') AS author
-    `;
-  }
   /**
    * Fetch a file's properties from database
    * This function is growing out of control, having to manage disk vs doc stored files, mtime aggregation, etc...
@@ -260,7 +248,7 @@ export default abstract class FilesVfs extends BaseVfs{
     let r = await this.db.get(`
       WITH scene AS (SELECT scene_id FROM scenes WHERE ${(is_string?"scene_name":"scene_id")} = $1 )
       SELECT
-        ${FilesVfs._fragFileProps({withData, table: "files", nameIndex: 2})}
+        ${FilesVfs._fragFileProps({withData, table: "files"})}
       FROM scene
       LEFT JOIN files ON files.fk_scene_id = scene.scene_id 
       WHERE files.name = $2
@@ -280,7 +268,7 @@ export default abstract class FilesVfs extends BaseVfs{
     let r = await this.db.get(`
       WITH ref AS (SELECT fk_scene_id, file_id, name, ctime, generation FROM files WHERE file_id = $3 AND fk_scene_id = $1)
       SELECT
-        ${FilesVfs._fragFileProps({withData: true, table: "files", nameIndex: 2})}
+        ${FilesVfs._fragFileProps({withData: true, table: "files"})}
       FROM ref INNER JOIN files USING(fk_scene_id) 
       WHERE files.name = $2
             AND (
@@ -310,7 +298,6 @@ export default abstract class FilesVfs extends BaseVfs{
    */
   async getFile(props:GetFileRangeParams): Promise<GetFileResult>{
     let r = await this.getFileProps(props, true);
-    if(!r.hash && !r.data) throw new NotFoundError(`Trying to open deleted file : ${ r.name }`);
     if(r.hash === "directory") return r;
 
     let handle :Readable;
@@ -339,7 +326,6 @@ export default abstract class FilesVfs extends BaseVfs{
   async getDoc(scene :string|number, lock=false) :Promise<DocProps>{
     let r = await this.getFileProps({scene, name: "scene.svx.json", lock}, true);
     if(!r.data)  throw new BadRequestError(`Not a valid document: ${ r.name }`);
-    if(Buffer.isBuffer(r.data)) r.data = r.data.toString("utf8");
     
     return r as DocProps;
   }
@@ -422,6 +408,7 @@ export default abstract class FilesVfs extends BaseVfs{
       let destFile = await tr.getFileProps({...props, name: nextName, archive: true})
       .catch(e=>{
         if(e.code == 404) return  {generation:0, hash:null};
+        /* c8 ignore next - getFileProps should only ever throw 404 errors */
         throw e;
       });
       if(destFile.hash){
@@ -430,8 +417,6 @@ export default abstract class FilesVfs extends BaseVfs{
 
       await tr.createFile(props, {hash: null, size: 0});
       let f = await tr.createFile({ ...props, mime:thisFile.mime, name: nextName}, thisFile);
-
-      if(!f?.id)  throw new NotFoundError(`can't create renamed file`);
       return f.id;
     });
   }

--- a/source/server/vfs/types.ts
+++ b/source/server/vfs/types.ts
@@ -25,7 +25,7 @@ export interface GetFileParams extends CommonFileParams{
   /**Also return deleted files */
   archive ?:boolean;
   generation ?:number;
-  //SELECT FOR UPDATE, use only within a transaction
+  /**SELECT FOR UPDATE, use only within a transaction. Might solve some transaction serialization troubles */
   lock?: boolean;
 }
 

--- a/source/ui/composants/HistoryAggregation.ts
+++ b/source/ui/composants/HistoryAggregation.ts
@@ -77,6 +77,9 @@ function bucketize(entries :HistoryEntry[], duration :number= (1/3)*24*60*60*100
 export class HistoryEntryAggregate extends i18n(LitElement){
   #c = new AbortController();
 
+  @property({attribute: true, type: Boolean })
+  write: boolean = false;
+
   @property({attribute: false, type: String})
   scene :string;
 
@@ -85,6 +88,9 @@ export class HistoryEntryAggregate extends i18n(LitElement){
 
   @property({attribute: "aria-selected", reflect: true})
   ariaSelected: "true"|"false" = "false";
+
+  @property({attribute: true, reflect: true, type: Boolean})
+  highlighted: boolean = false;
 
   @state()
   diff ?:Partial<EntryDiff>;
@@ -117,7 +123,14 @@ export class HistoryEntryAggregate extends i18n(LitElement){
   }
 
   connectedCallback(): void {
-    this.classList.add("history-entry-line")
+    this.classList.add("history-entry-line");
+    let {activeId} = window.history.state ?? {};
+    console.log("Active ID:", activeId);
+    if(activeId &&  this.id == activeId){
+      this.highlighted = true;
+    }else if(activeId && this.id.length < activeId.length && activeId.startsWith(this.id)){
+      this.ariaSelected = "true"
+    }
     super.connectedCallback();
   }
 
@@ -180,7 +193,10 @@ export class HistoryEntryAggregate extends i18n(LitElement){
     </div>`;
   }
 
-  
+  /**
+   * Renders a summary of this aggregation.
+   * Adds appropriate expand/collapse buttons and actions
+   */
   protected renderSummary({id, name, restorePoint, authoredBy, from, to}:HistorySummary){
     const selected = this.ariaSelected === "true";
     const expand = (this.entries.length === 1)?html`
@@ -195,7 +211,7 @@ export class HistoryEntryAggregate extends i18n(LitElement){
     </div>`: null;
     
     const longAction = selected && this.entries.length === 1
-    const action = html`<div class="history-actions" style="display: flex;justify-content: end;">
+    const action = this.write? html`<div class="history-actions" style="display: flex;justify-content: end;">
       <ui-button
         style="margin-top:-1px"
         class="btn btn-primary ${(longAction)?"btn-outline":"btn-small btn-transparent hover-only"} btn-rollback"
@@ -206,10 +222,12 @@ export class HistoryEntryAggregate extends i18n(LitElement){
         }}
         icon="restore"
       ></ui-button>
-      <a href="history/${restorePoint}/view" @click=${(e)=>e.stopPropagation()} title="${this.t("info.viewAtThisPoint")}" class="btn btn-secondary btn-small btn-transparent btn-inline">
+      <a href="history/${restorePoint}/view" 
+        @click=${(e)=>e.stopPropagation()}
+        title="${this.t("info.viewAtThisPoint")}" class="btn btn-secondary btn-small btn-transparent btn-inline">
         <ui-icon name="eye"></ui-icon>
       </a>
-    </div>`;
+    </div>`:"";
 
     const toDate = (to.valueOf() != from.valueOf())? html` - <span style="opacity:0.75; font-size: 90%; font-family: monospace">${to.toLocaleTimeString(this.language)}</span>`: null;
     
@@ -230,6 +248,7 @@ export class HistoryEntryAggregate extends i18n(LitElement){
     ${showDiff}
     `;
   }
+
 
   protected renderEntry(entry:HistoryEntry){
     const selected = this.ariaSelected === "true";
@@ -263,7 +282,7 @@ export class HistoryEntryAggregate extends i18n(LitElement){
     const selected = this.ariaSelected === "true";
 
     if(selected){
-      return bucketize(entries).map((bucket, index)=>html`<history-entry-aggregate id=${this.id+"-"+index.toString(10)} role="treeitem" aria-disabled=${index ===0? this.getAttribute("aria-disabled"): "false"} .scene=${this.scene} .entries=${bucket}></history-entry-aggregate>`);
+      return bucketize(entries).map((bucket, index)=>html`<history-entry-aggregate  ?write=${this.write} id=${this.id+"-"+index.toString(10)} role="treeitem" aria-disabled=${index ===0? this.getAttribute("aria-disabled"): "false"} .scene=${this.scene} .entries=${bucket}></history-entry-aggregate>`);
     }
 
 
@@ -305,6 +324,10 @@ export class HistoryEntryAggregate extends i18n(LitElement){
 
 @customElement("history-aggregation")
 export default class HistoryAggregation extends i18n(LitElement){
+
+  @property({attribute: true, type: Boolean })
+  write: boolean = false;
+
   @property({attribute: false, type: String})
   scene :string;
 
@@ -327,7 +350,7 @@ export default class HistoryAggregation extends i18n(LitElement){
         • ${this.t("info.changeDay", {date: day[0].ctime.toLocaleDateString(this.language)})}
       </h4>
       <div class="history-day-content">
-        <history-entry-aggregate role="treeitem" aria-selected="${1 <day.length?"true":"false"}" .scene=${this.scene} .entries=${day} id=${"day-group-"+index.toString(10)} aria-disabled=${index === 0? "true":"false"}></history-entry-aggregate>
+        <history-entry-aggregate ?write=${this.write} role="treeitem" aria-selected="${1 <day.length?"true":"false"}" .scene=${this.scene} .entries=${day} id=${"day-group-"+index.toString(10)} aria-disabled=${index === 0? "true":"false"}></history-entry-aggregate>
       </div>
       <span class="caret" @click=${handleCollapse}></span>
     </div>`;
@@ -409,6 +432,14 @@ export default class HistoryAggregation extends i18n(LitElement){
         &:hover:not(.active),
         &:hover:not(:has(.history-entry-line)) {
           border-top-color: var(--color-primary);
+          & .btn-rollback.hover-only{
+            opacity: 1;
+          }
+        }
+
+        &:has(> .history-point > .history-actions:focus-within) {
+          border: 1px solid var(--color-primary);
+          border-left-width: 0.7rem;
           & .btn-rollback.hover-only{
             opacity: 1;
           }

--- a/source/ui/composants/HistoryAggregation.ts
+++ b/source/ui/composants/HistoryAggregation.ts
@@ -111,7 +111,7 @@ export class HistoryEntryAggregate extends i18n(LitElement){
       this.diff = await r.json();
     }).catch(e=>{
       if(e.name === "AbortError") return;
-      console.error(e);
+      console.error("Diff request failed: ", e.message);
       this.diff = {diff: `Error failing diff : ${e.message}`}
     });
   }
@@ -167,14 +167,14 @@ export class HistoryEntryAggregate extends i18n(LitElement){
     
     return html`<div class="history-entry-diff-block">
       <p>
-        ${(src.size !=0 && src.size != dst.size)?  html`
+        ${(src?.size && src.size != dst.size)?  html`
           Size changed from
           <span class="text-info"><b-size b=${src.size}></b-size></span>
           to
           <span class="text-info"><b-size b=${dst.size}></b-size></span>
           .
         ` : null}
-        ${(new Date(src.ctime).valueOf() != 0)? html`Previous version was saved on <span class="text-info">${new Date(src.ctime).toLocaleString(this.language)}</span>`:null}
+        ${(src?.ctime && new Date(src.ctime).valueOf() != 0)? html`Previous version was saved on <span class="text-info">${new Date(src.ctime).toLocaleString(this.language)}</span>`:null}
       </p>
       ${diffBlock}
     </div>`;
@@ -183,7 +183,6 @@ export class HistoryEntryAggregate extends i18n(LitElement){
   
   protected renderSummary({id, name, restorePoint, authoredBy, from, to}:HistorySummary){
     const selected = this.ariaSelected === "true";
-    
     const expand = (this.entries.length === 1)?html`
       <ui-button @click=${this.toggleSelect} class="btn btn-small btn-transparent btn-inline" text=${selected?"⌃":"⌄"}></ui-button>
     `: html`
@@ -196,7 +195,7 @@ export class HistoryEntryAggregate extends i18n(LitElement){
     </div>`: null;
     
     const longAction = selected && this.entries.length === 1
-    const action = html`<div style="display: flex;justify-content: end;">
+    const action = html`<div class="history-actions" style="display: flex;justify-content: end;">
       <ui-button
         style="margin-top:-1px"
         class="btn btn-primary ${(longAction)?"btn-outline":"btn-small btn-transparent hover-only"} btn-rollback"
@@ -207,6 +206,9 @@ export class HistoryEntryAggregate extends i18n(LitElement){
         }}
         icon="restore"
       ></ui-button>
+      <a href="history/${restorePoint}/view" @click=${(e)=>e.stopPropagation()} title="${this.t("info.viewAtThisPoint")}" class="btn btn-secondary btn-small btn-transparent btn-inline">
+        <ui-icon name="eye"></ui-icon>
+      </a>
     </div>`;
 
     const toDate = (to.valueOf() != from.valueOf())? html` - <span style="opacity:0.75; font-size: 90%; font-family: monospace">${to.toLocaleTimeString(this.language)}</span>`: null;
@@ -414,8 +416,10 @@ export default class HistoryAggregation extends i18n(LitElement){
 
         &[aria-disabled="true"] {
           border-top-color: transparent !important;
-          > .history-point .btn-rollback {
+          > .history-point .history-actions .btn {
             opacity: 0 !important;
+            pointer-events: none;
+            cursor: auto;
           }
         }
 

--- a/source/ui/screens/SceneHistory.ts
+++ b/source/ui/screens/SceneHistory.ts
@@ -1,4 +1,4 @@
-import { LitElement, TemplateResult, html, render } from 'lit';
+import { LitElement, TemplateResult, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 import Notification from "../composants/Notification";
@@ -10,11 +10,8 @@ import "../composants/HistoryAggregation";
 
 import i18n from "../state/translate";
 import { withUser } from "../state/auth";
-import { navigate } from "../state/router";
-import { AccessType, AccessTypes, Scene } from "../state/withScenes";
-import HttpError from "../state/HttpError";
+import { AccessType } from "../state/withScenes";
 import { HistoryEntry, HistoryEntryJSON } from "../composants/HistoryAggregation";
-import { createDialog, showFormModal, showTaskModal } from '../state/dialog';
 
 
 
@@ -52,7 +49,7 @@ interface AccessRights{
   createRenderRoot() {
       return this;
   }
-    
+
   public connectedCallback(): void {
       super.connectedCallback();
       this.fetchHistory();

--- a/source/ui/screens/SceneHistory.ts
+++ b/source/ui/screens/SceneHistory.ts
@@ -33,6 +33,8 @@ interface AccessRights{
   @property()
   name :string;
 
+  @property({attribute: true, type: Boolean})
+  write: boolean = false;
 
   @property({attribute: false, type:Array})
   versions : HistoryEntry[];
@@ -84,7 +86,7 @@ interface AccessRights{
             <h1></h1>
         </div>`;
       }
-      return html`<history-aggregation .entries=${this.versions} .scene=${this.name} @restore=${this.onRestore}></history-aggregation>`;
+      return html`<history-aggregation .entries=${this.versions} .scene=${this.name} ?write=${this.write} @restore=${this.onRestore}></history-aggregation>`;
   }
 
   onRestore = (e :CustomEvent<number>)=>{

--- a/source/ui/state/strings.ts
+++ b/source/ui/state/strings.ts
@@ -302,6 +302,10 @@ export default {
     restoredTo: {
       fr: "scène restaurée à {point}",
       en: "scene restored to {point}",
+    },
+    viewAtThisPoint: {
+      fr: "Voir la scène à ce moment",
+      en: "View scene at this point",
     }
   },
   errors:{

--- a/source/ui/styles/buttons.scss
+++ b/source/ui/styles/buttons.scss
@@ -69,7 +69,7 @@ a{
     background-color: var(--color-secondary);
 
     &:hover:not([disabled]){
-      background-color: var(--color-secondary);
+      background-color: var(--color-secondary-light);
     }
   }
 
@@ -120,6 +120,7 @@ a{
     &:hover:not([disabled]){
       box-shadow: none !important;
     }
+
     &.btn-primary{
       color: var(--color-primary);
       &:hover:not([disabled]){
@@ -127,6 +128,17 @@ a{
         color: var(--color-primary-light);
       }
     }
+
+    &.btn-secondary {
+      color: var(--color-secondary);
+
+      &:hover:not([disabled]){
+        color: var(--color-secondary-light);
+      }
+    }
+
+
+
     &.btn-danger {
       color: var(--color-error);
       &:hover:not([disabled]){


### PR DESCRIPTION
This proposed API would allow to view a scene in Voyager as it was at an arbitrary point in time.

From the "history" view, one would be able to check whether or not the scene was in the searched-for state at a given point in time. It also allow finding deleted data without having to overwrite the current scene.

### Added routes:

#### GET /history/:scene/:id/show/:name(*)


Uses `Vfs.getFileBefore()` to fetch scene files before a reference point.

#### GET /ui/scenes/:scene/history/:id/view

Modified `<voyager-explorer>` view that uses `/history/:scene/:id/show` as `ExplorerApplication.documentRoot`.


### Comments

Both routes being read-only, the can be restricted to `"read"` access level. However, access rights to `/ui/scenes/:scene/history` requires `"admin"` access at the moment and it's the only way to get a time-machine URI.

Either we assume only admins will generate those URIs but we want them to be publicly (as public as the scene itself) readable. Or we make the history page accessible with `"read"` rights with a flag on `<scene-history>` to hide the restore button.
