### PR TITLE
put documents structured merge in a task to allow advanced debugging

### DIFF
--- a/source/server/routes/scenes/scene/files/put/document.ts
+++ b/source/server/routes/scenes/scene/files/put/document.ts
@@ -1,19 +1,18 @@
 import {debuglog} from 'util';
 import { Request, Response } from "express";
 
-import * as merge from "../../../../../utils/merge/index.js";
 import { BadRequestError } from "../../../../../utils/errors.js";
 import { getLocals, getUserId, getVfs } from "../../../../../utils/locals.js";
+import { structuredDocMerge } from '../../../../../tasks/handlers/structuredDocMerge.js';
 
 const debug = debuglog("http:body");
-const debugmerge = debuglog("http:merge");
 /**
  * Special handler for svx files to disallow the upload of invalid JSON.
  * @todo Should check against the official json schema using ajv
  * If the user provides a reference document ID and the document has been updated since, a diff is performed to try to merge the changes.
  */
 export default async function handlePutDocument(req :Request, res :Response){
-  const {config} = getLocals(req);
+  const {config, taskScheduler, vfs} = getLocals(req);
   const uid = getUserId(req);
   const {scene:sceneName} = req.params;
   const newDoc = req.body;
@@ -28,48 +27,18 @@ export default async function handlePutDocument(req :Request, res :Response){
     await getVfs(req).writeDoc(JSON.stringify(newDoc), {scene: sceneName, user_id: uid, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json"});
     return res.status(204).send();
   }
-
-  let code = await getVfs(req).isolate(async function applyStructuredMerge(tr):Promise<204|205>{
-    let {id: scene} = await tr.getScene(sceneName);
-    // perform a diff of the document with the reference one
-    const {data: currentDocString, id: currentDocId, generation: currentDocGeneration} = await tr.getDoc(scene, true);
-    const currentDoc = JSON.parse(currentDocString);
-    let refDocString :string;
-    if(refId === currentDocId){
-      refDocString = currentDocString;
-    }else{
-      const refDoc = await tr.getFileById(refId);
-      if(refDoc.scene_id !== scene) throw new BadRequestError(`Document's reference ID is not in this scene`);
-      refDocString = refDoc.data!;
-    }
-
-    if(!refDocString) throw new BadRequestError(`Referenced document is not valid`);
-    const refDoc = JSON.parse(refDocString);
-
-    //console.log("Ref doc :", JSON.stringify(refDoc.setups![0].tours, null, 2));
-    //console.log("New doc :", JSON.stringify(newDoc.setups![0].tours, null, 2));
-    const docDiff = merge.diffDoc(refDoc, newDoc);
-    if(Object.keys(docDiff).length == 0){
-      debugmerge("detected identical documents");
-      //Nothing to do
-      return 204;
-    }
-
-    //console.log("Diff :", JSON.stringify(docDiff, (key, value)=> value === merge.DELETE_KEY? "*DELETED*":value, 2));
-    if(refId == currentDocId){
-      //Simple overwrite
-      await tr.writeDoc(JSON.stringify(newDoc), {scene, user_id: uid, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json"});
-      return 205; //Reset Content
-    }else{
-      const mergedDoc = merge.applyDoc(currentDoc, docDiff);
-      let s = JSON.stringify(mergedDoc);
-      let {id, generation} = await tr.writeDoc(s, {scene, user_id: uid, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json"});
-      if(currentDocGeneration+1 < generation){
-        debugmerge(`performed a three point merge from ${currentDocId} to ${id}`);
-        debugmerge(`Using diff: ${docDiff}`);
-      }
-      return 204;
-    }
+  let {id: scene_id} = await vfs.getScene(sceneName);
+  //Run the merge in a task so we get more logs when necessary
+  let code = await taskScheduler.run({
+    immediate: true,
+    scene_id,
+    user_id: uid,
+    data: {
+      docData: newDoc,
+      refId,
+    },
+    handler: structuredDocMerge,
   });
+  
   res.status(code).send();
 };

--- a/source/server/tasks/handlers/structuredDocMerge.ts
+++ b/source/server/tasks/handlers/structuredDocMerge.ts
@@ -1,0 +1,59 @@
+
+import { BadRequestError, InternalError } from "../../utils/errors.js";
+import * as merge from "../../utils/merge/index.js";
+import { IDocument } from "../../utils/schema/document.js";
+import { TaskHandlerParams } from "../types.js";
+
+export interface DocMergeData{
+  docData: IDocument;
+  refId: number;
+}
+/**
+ * 
+ * @param param0 
+ * @returns 204 the merge was fast-forward. 205 if the user should reload content
+ */
+export async function structuredDocMerge({context: {vfs:_vfs, logger}, task: {scene_id, user_id, data: {refId, docData: newDoc}}}:TaskHandlerParams<DocMergeData>): Promise<204|205> {
+  if(typeof scene_id !== "number") throw new InternalError(`Can't perform structured merge with no assigned scene_id`);
+  if(typeof user_id !== "number") throw new InternalError(`Can't perform structured merge with no assigned user_id`);
+  return await _vfs.isolate(async function applyStructuredMerge(tr):Promise<204|205>{
+    // perform a diff of the document with the reference one
+    const {data: currentDocString, id: currentDocId, generation: currentDocGeneration} = await tr.getDoc(scene_id, true);
+    const currentDoc = JSON.parse(currentDocString);
+    let refDocString :string;
+    if(refId === currentDocId){
+      refDocString = currentDocString;
+    }else{
+      const refDoc = await tr.getFileById(refId);
+      if(refDoc.scene_id !== scene_id) throw new BadRequestError(`Document's reference ID is not in this scene`);
+      refDocString = refDoc.data!;
+    }
+
+    if(!refDocString) throw new BadRequestError(`Referenced document is not valid`);
+    const refDoc = JSON.parse(refDocString);
+
+    logger.debug("Ref doc :", JSON.stringify(refDoc.setups![0].tours, null, 2));
+    const docDiff = merge.diffDoc(refDoc, newDoc);
+    if(Object.keys(docDiff).length == 0){
+      logger.log("detected identical documents");
+      //Nothing to do
+      return 204;
+    }
+
+    logger.debug("Diff :", JSON.stringify(docDiff, (key, value)=> value === merge.DELETE_KEY? "*DELETED*":value, 2));
+    if(refId == currentDocId){
+      //Simple overwrite
+      await tr.writeDoc(JSON.stringify(newDoc), {scene:scene_id, user_id, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json"});
+      return 205; //Reset Content
+    }else{
+      const mergedDoc = merge.applyDoc(currentDoc, docDiff);
+      let s = JSON.stringify(mergedDoc);
+      let {id, generation} = await tr.writeDoc(s, {scene: scene_id, user_id: user_id, name: "scene.svx.json", mime: "application/si-dpo-3d.document+json"});
+      if(currentDocGeneration+1 < generation){
+        logger.log(`performed a three point merge from ${currentDocId} to ${id}`);
+        logger.log(`Using diff: ${docDiff}`);
+      }
+      return 204;
+    }
+  });
+}


### PR DESCRIPTION
Uses verbose logging to provide ample debugging data for merge errors and inconsistencies troubleshooting.