### PR TITLE
Add pagination support to user listing endpoints

### DIFF
--- a/source/e2e/tests/admin.spec.ts
+++ b/source/e2e/tests/admin.spec.ts
@@ -23,6 +23,21 @@ test("can create a new user", async ({page})=>{
   await expect(page.getByRole("table").getByText(name, {exact: true})).toBeVisible();
 });
 
+test("shows the email of users in the admin users list", async ({page, request})=>{
+  let username = `test-emailcol-${randomBytes(6).toString("base64url")}`;
+  let email = `${username}@example.com`;
+  let res = await request.post("/users", {
+    data: {username, password: randomUUID(), email},
+  });
+  await expect(res).toBeOK();
+
+  await page.goto("/ui/admin/users");
+
+  let userRow = page.getByRole("row", {name: username});
+  await expect(userRow).toBeVisible();
+  await expect(userRow.getByRole("link", {name: email})).toBeVisible();
+});
+
 test("can delete a non-admin user", async ({page, request})=>{
   let username = `test-deleteuser-${randomBytes(6).toString("base64url")}`;
   let u = {

--- a/source/server/auth/UserManager.test.ts
+++ b/source/server/auth/UserManager.test.ts
@@ -155,6 +155,75 @@ describe("UserManager methods", function(){
     });
   });
 
+  describe("getUsers()", function(){
+    let dbUri :string, um :UserManager;
+    this.beforeAll(async function(){
+      // Use an isolated DB so previously created users don't interfere with counts/offsets
+      dbUri = await getUniqueDb("userManager-getUsers-test-"+randomBytes(2).toString("hex"));
+      this.db2 = await openDatabase({uri: dbUri, forceMigration: true});
+      um = new UserManager(this.db2);
+      for(let i = 0; i < 15; i++){
+        await um.addUser(`getusers_${i.toString(10).padStart(3, "0")}`, "abcdefghij", "use");
+      }
+    });
+    this.afterAll(async function(){
+      await this.db2.end();
+      await dropDb(dbUri);
+    });
+
+    it("returns all users by default", async function(){
+      const users = await um.getUsers();
+      expect(users).to.have.property("length", 15);
+    });
+
+    it("applies limit", async function(){
+      const users = await um.getUsers(true, {limit: 5});
+      expect(users).to.have.property("length", 5);
+    });
+
+    it("applies offset", async function(){
+      const users = await um.getUsers(true, {offset: 10});
+      expect(users).to.have.property("length", 5);
+    });
+
+    it("combines limit and offset", async function(){
+      const first = await um.getUsers(true, {limit: 5});
+      const next = await um.getUsers(true, {limit: 5, offset: 5});
+      expect(next).to.have.property("length", 5);
+      // Ensure the second page doesn't overlap the first
+      const firstNames = first.map(u=>u.username);
+      for(const u of next){
+        expect(firstNames).not.to.include(u.username);
+      }
+    });
+
+    it("rejects invalid limit", async function(){
+      await expect(um.getUsers(true, {limit: 0})).to.be.rejectedWith(BadRequestError);
+      await expect(um.getUsers(true, {limit: 101})).to.be.rejectedWith(BadRequestError);
+      await expect(um.getUsers(true, {limit: 1.5})).to.be.rejectedWith(BadRequestError);
+    });
+
+    it("rejects invalid offset", async function(){
+      await expect(um.getUsers(true, {offset: -1})).to.be.rejectedWith(BadRequestError);
+      await expect(um.getUsers(true, {offset: 1.5})).to.be.rejectedWith(BadRequestError);
+    });
+
+    it("orders results by username (stable across pages)", async function(){
+      const all = await um.getUsers();
+      const sorted = [...all].map(u=>u.username).sort();
+      expect(all.map(u=>u.username)).to.deep.equal(sorted);
+    });
+  });
+
+  describe("userCount()", function(){
+    it("returns the number of users excluding system users", async function(){
+      const before = await userManager.userCount();
+      await userManager.addUser("bob-user-count-1", "abcdefghij");
+      const after = await userManager.userCount();
+      expect(after).to.equal(before + 1);
+    });
+  });
+
   describe("removeUser()", function(){
     it("remove a user", async function(){
       let u = await userManager.addUser("bob-remove-user-1", "abcdefghij");

--- a/source/server/auth/UserManager.ts
+++ b/source/server/auth/UserManager.ts
@@ -55,6 +55,11 @@ export type AccessType = typeof AccessTypes[number];
 
 export type AccessMap = {[id: `${number}`|string]:AccessType};
 
+export interface UserQuery {
+  offset?: number;
+  limit?: number;
+}
+
 export const any_id = 1 as const;
 export const default_id = 0 as const;
 
@@ -203,22 +208,53 @@ export default class UserManager extends DbController {
   }
   
   /**
+   * Validate pagination parameters for getUsers().
+   * Mirrors ScenesVfs._validateSceneQuery() for consistency.
+   */
+  static _validateUserQuery(q :Readonly<UserQuery|any>) :UserQuery{
+    if(typeof q.limit !== "undefined"){
+      if(typeof q.limit != "number" || Number.isNaN(q.limit) || !Number.isInteger(q.limit)) throw new BadRequestError(`When provided, limit must be an integer`);
+      if(q.limit <= 0) throw new BadRequestError(`When provided, limit must be >0`);
+      if(100 < q.limit) throw new BadRequestError(`When provided, limit must be <= 100`);
+    }
+    if(typeof q.offset !== "undefined"){
+      if(typeof q.offset != "number" || Number.isNaN(q.offset) || !Number.isInteger(q.offset)) throw new BadRequestError(`When provided, offset must be an integer`);
+      if(q.offset < 0) throw new BadRequestError(`When provided, offset must be >= 0`);
+    }
+    return q;
+  }
+
+  /**
    * List users
    */
    async getUsers() :Promise<SafeUser[]>
-   async getUsers(safe :true) :Promise<SafeUser[]>
-   async getUsers(safe :false) :Promise<User[]>
-   async getUsers(safe :boolean =true){
+   async getUsers(safe :true, q ?:UserQuery) :Promise<SafeUser[]>
+   async getUsers(safe :false, q ?:UserQuery) :Promise<User[]>
+   async getUsers(safe :boolean, q ?:UserQuery) :Promise<SafeUser[]|User[]>
+   async getUsers(safe :boolean =true, q :UserQuery = {}){
+    const {limit, offset = 0} = UserManager._validateUserQuery(q);
+    const args :any[] = [offset];
+    let limitClause = "";
+    if(typeof limit === "number"){
+      args.push(limit);
+      limitClause = `LIMIT $2`;
+    }
     return (await this.db.all<StoredUser>(`
-      SELECT ${safe?"user_id, username, email, level":"*"} 
+      SELECT ${safe?"user_id, username, email, level":"*"}
       FROM users
-      WHERE user_id NOT IN (0, 1)`)).map(u=>UserManager.deserialize(u));
+      WHERE user_id NOT IN (0, 1)
+      ORDER BY username ASC
+      OFFSET $1
+      ${limitClause}`, args)).map(u=>UserManager.deserialize(u));
   }
 
   async userCount() :Promise<number>{
-    let r = (await this.db.all(`SELECT COUNT(user_id) as count FROM users`))[0];
+    let r = (await this.db.all<{count: number|string}>(`
+      SELECT COUNT(user_id) as count
+      FROM users
+      WHERE user_id NOT IN (0, 1)`))[0];
     if(!r) throw new InternalError(`Bad db configuration : can't get user count`);
-    return r.count;
+    return typeof r.count === "string" ? parseInt(r.count, 10) : r.count;
   }
   /**
    * 

--- a/source/server/routes/users/index.ts
+++ b/source/server/routes/users/index.ts
@@ -4,6 +4,7 @@ import { Router } from "express";
 import UserManager from "../../auth/UserManager.js";
 import { getUserManager, isAdministrator, isAdministratorOrOpen, isUser } from "../../utils/locals.js";
 import wrap from "../../utils/wrapAsync.js";
+import { qsToInt } from "../../utils/query.js";
 import bodyParser from "body-parser";
 
 import postUser from "./post.js";
@@ -27,7 +28,10 @@ router.get("/", isAdministrator, wrap(async (req, res)=>{
   let userManager :UserManager = getUserManager(req);
   //istanbul ignore if
   if(!userManager) throw new Error("Badly configured app : userManager is not defined in app.locals");
-  let users = await userManager.getUsers(true);
+  let users = await userManager.getUsers(true, {
+    limit: qsToInt(req.query.limit),
+    offset: qsToInt(req.query.offset),
+  });
   res.status(200).send(users);
 }));
 

--- a/source/server/routes/users/users.test.ts
+++ b/source/server/routes/users/users.test.ts
@@ -123,6 +123,55 @@ describe("/users", function(){
           expect(user).not.to.have.property("password");
         }
       })
+
+      describe("supports pagination", function(){
+        this.beforeEach(async function(){
+          // Add extra users to exercise pagination (we already have 2)
+          for(let i = 0; i < 12; i++){
+            await userManager.addUser(`paginated_${i.toString(10).padStart(3, "0")}`, "abcdefghij", "use");
+          }
+        });
+
+        it("accepts a limit parameter", async function(){
+          let res = await this.agent.get("/users?limit=5")
+          .set("Accept", "application/json")
+          .expect(200);
+          expect(res.body).to.have.property("length", 5);
+        });
+
+        it("accepts an offset parameter", async function(){
+          // 2 base users (alice, bob) + 12 paginated_xxx = 14 total
+          let res = await this.agent.get("/users?offset=10")
+          .set("Accept", "application/json")
+          .expect(200);
+          expect(res.body).to.have.property("length", 4);
+        });
+
+        it("combines limit and offset", async function(){
+          let res = await this.agent.get("/users?limit=3&offset=3")
+          .set("Accept", "application/json")
+          .expect(200);
+          expect(res.body).to.have.property("length", 3);
+        });
+
+        it("rejects an invalid limit", async function(){
+          await this.agent.get("/users?limit=foo")
+          .set("Accept", "application/json")
+          .expect(400);
+        });
+
+        it("rejects a negative offset", async function(){
+          await this.agent.get("/users?offset=-1")
+          .set("Accept", "application/json")
+          .expect(400);
+        });
+
+        it("rejects a limit over 100", async function(){
+          await this.agent.get("/users?limit=200")
+          .set("Accept", "application/json")
+          .expect(400);
+        });
+      });
   
       it("can create a user", async function(){
         await this.agent.post("/users")

--- a/source/server/routes/views/index.ts
+++ b/source/server/routes/views/index.ts
@@ -391,13 +391,39 @@ routes.get("/admin/archives", isAdministrator, wrap(async (req, res)=>{
 }));
 
 routes.get("/admin/users", wrap(async (req, res)=>{
-  let users = await getUserManager(req).getUsers();
+  const host = getHost(req);
+  const userManager = getUserManager(req);
+  const limit = qsToInt(req.query.limit) ?? 25;
+  const offset = qsToInt(req.query.offset) ?? 0;
+
+  const [users, total] = await Promise.all([
+    userManager.getUsers(true, {limit, offset}),
+    userManager.userCount(),
+  ]);
+
+  let pager = {
+    from: offset,
+    to: offset + users.length,
+    total,
+    next: undefined as string|undefined,
+    previous: undefined as string|undefined,
+  };
+  if(limit === users.length && offset + users.length < total){
+    const nextUrl = new URL(req.originalUrl, host);
+    nextUrl.searchParams.set("offset", (offset+limit).toString());
+    pager.next = nextUrl.pathname+nextUrl.search;
+  }
+  if(offset){
+    const prevUrl = new URL(req.originalUrl, host);
+    prevUrl.searchParams.set("offset", Math.max(0, offset - limit).toString());
+    pager.previous = prevUrl.pathname+prevUrl.search;
+  }
+
   res.render("admin/users", {
     layout: "admin",
     title: "Users list — Administration",
-    start: 0,
-    end: 0 + users.length,
-    total: users.length,
+    params: {limit, offset},
+    pager,
     users,
   });
 }));

--- a/source/server/templates/admin/users.hbs
+++ b/source/server/templates/admin/users.hbs
@@ -14,15 +14,17 @@
     <thead><tr>
         <th>uid</th>
         <th>{{i18n "labels.username"}}</th>
+        <th>{{i18n "labels.email"}}</th>
         <th>{{i18n "labels.role"}}</th>
         <th></th>
     </tr></thead>
     <tbody>
       {{#each users}}
         <tr aria-labelledby="user-row-{{uid}}">
-          <td style="font-family:monospace;">{{uid}}</td>
+          <td class="compact" style="font-family:monospace;">{{uid}}</td>
           <td id="user-row-{{uid}}">{{username}}</td>
-          <td>
+          <td>{{#if email}}<a href="mailto:{{email}}">{{email}}</a>{{else}}&mdash;{{/if}}</td>
+          <td class="compact">
             {{#if (test @root.user.level "==" "admin")}}
               {{#unless (test uid "==" ../user.uid)}}
               <submit-fragment method="PATCH" action="/users/{{uid}}" encoding="application/json"  submit="level" onsubmit="window.location.reload()">
@@ -44,22 +46,21 @@
                 <div>{{level}}</div>
             {{/if}}
           </td>
-          <td>
+          <td class="compact">
           {{#if (test @root.user.level "==" "admin")}}
             <div style="display:flex; justify-content:end;gap:.6rem;">
+              <button data-username="{{username}}" aria-label="{{i18n "labels.loginLink"}}" title="{{i18n "labels.loginLink"}}" class="btn btn-inline btn-icon btn-loginlink">
+                <ui-icon name="key"></ui-icon>
+              </button>
               {{#if (test level "!=" "admin")}}
               <submit-fragment method="DELETE" action="/users/{{uid}}" encoding="application/json"  onsubmit="window.location.reload()">
                 <form>
-                  <button role="submit" class="btn btn-inline btn-icon btn-danger" aria-label="{{i18n "labels.delete"}}">
+                  <button role="submit" class="btn btn-inline btn-icon btn-danger" aria-label="{{i18n "labels.delete"}}" title="{{i18n "labels.delete"}}">
                     <ui-icon name="trash"></ui-icon>
                   </button>
                 </form>
               </submit-fragment>
               {{/if}}
-              
-              <button data-username="{{username}}" aria-label="{{i18n "labels.loginLink"}}" class="btn btn-inline btn-icon btn-loginlink">
-                <ui-icon name="key"></ui-icon>
-              </button>
             </div>
           {{/if}}
           </td>
@@ -69,9 +70,17 @@
   </table>
 </div>
 {{#if users.length}}
-  <div style="text-align: right;padding: .4rem 1rem;">{{i18n "leads.usersList" start=start end=end total=total}}</div>
+  {{#with pager}}
+    {{> pager }}
+  {{/with}}
 {{else}}
+  {{#if pager.previous}}
+    {{#with pager}}
+      {{> pager }}
+    {{/with}}
+  {{else}}
     <div style="text-align: center;">No user registered. Click the <ui-icon name="plus"></ui-icon> to add one</div>
+  {{/if}}
 {{/if}}
 
 {{#if (test @root.user.level "==" "admin")}}

--- a/source/server/templates/admin/users.hbs
+++ b/source/server/templates/admin/users.hbs
@@ -15,7 +15,11 @@
     .users-list table.list-table td.col-email {
       white-space: normal;
       word-break: break-word;
-      max-width: 20ch;
+      max-width: 20em;
+    }
+    .users-list table.list-table td.col-level,
+    .users-list table.list-table td.col-actions{
+      padding: 0 15px;
     }
     .users-list table.list-table td.col-level select {
       width: auto;
@@ -35,7 +39,7 @@
           <td class="compact" style="font-family:monospace;">{{uid}}</td>
           <td class="col-name" id="user-row-{{uid}}">{{username}}</td>
           <td class="col-email">{{#if email}}<a href="mailto:{{email}}">{{email}}</a>{{else}}&mdash;{{/if}}</td>
-          <td class="compact col-level">
+          <td class="col-level">
             {{#if (test @root.user.level "==" "admin")}}
               {{#unless (test uid "==" ../user.uid)}}
               <submit-fragment method="PATCH" action="/users/{{uid}}" encoding="application/json"  submit="level" onsubmit="window.location.reload()">
@@ -57,7 +61,7 @@
                 <div>{{level}}</div>
             {{/if}}
           </td>
-          <td class="compact">
+          <td class="compact col-actions">
           {{#if (test @root.user.level "==" "admin")}}
             <div style="display:flex; justify-content:end;gap:.6rem;">
               <button data-username="{{username}}" aria-label="{{i18n "labels.loginLink"}}" title="{{i18n "labels.loginLink"}}" class="btn btn-inline btn-icon btn-loginlink">

--- a/source/server/templates/admin/users.hbs
+++ b/source/server/templates/admin/users.hbs
@@ -10,6 +10,17 @@
 </div>
 
 <div class="list-table-wrap users-list flush" style="position:relative;">
+  <style>
+    .users-list table.list-table td.col-name,
+    .users-list table.list-table td.col-email {
+      white-space: normal;
+      word-break: break-word;
+      max-width: 20ch;
+    }
+    .users-list table.list-table td.col-level select {
+      width: auto;
+    }
+  </style>
   <table class="list-table">
     <thead><tr>
         <th>uid</th>
@@ -22,9 +33,9 @@
       {{#each users}}
         <tr aria-labelledby="user-row-{{uid}}">
           <td class="compact" style="font-family:monospace;">{{uid}}</td>
-          <td id="user-row-{{uid}}">{{username}}</td>
-          <td>{{#if email}}<a href="mailto:{{email}}">{{email}}</a>{{else}}&mdash;{{/if}}</td>
-          <td class="compact">
+          <td class="col-name" id="user-row-{{uid}}">{{username}}</td>
+          <td class="col-email">{{#if email}}<a href="mailto:{{email}}">{{email}}</a>{{else}}&mdash;{{/if}}</td>
+          <td class="compact col-level">
             {{#if (test @root.user.level "==" "admin")}}
               {{#unless (test uid "==" ../user.uid)}}
               <submit-fragment method="PATCH" action="/users/{{uid}}" encoding="application/json"  submit="level" onsubmit="window.location.reload()">

--- a/source/ui/styles/buttons.scss
+++ b/source/ui/styles/buttons.scss
@@ -150,7 +150,11 @@ a{
   // --- Modifiers ---
 
   &.btn-inline {
-    display: inline-block;
+    display: inline;
+    height: 1.5em;
+    padding: 0em .5em;
+    min-width: 0;
+    border-radius: 4px;
   }
 
   &.btn-outline {


### PR DESCRIPTION
## Summary
This PR adds pagination support to user listing functionality across the application, including the admin users page, API endpoint, and underlying UserManager class. It also improves the admin users table UI by displaying user emails and reorganizing action buttons.

## Key Changes

### Core Functionality
- **UserManager pagination**: Added `UserQuery` interface with `limit` and `offset` parameters to `getUsers()` method
  - Implements validation mirroring `ScenesVfs._validateSceneQuery()` for consistency
  - Validates limit (1-100, integer) and offset (≥0, integer)
  - Results ordered by username for stable pagination across pages
  
- **User count method**: Updated `userCount()` to exclude system users (IDs 0 and 1) to match listing behavior

### API Endpoint
- `/users` GET endpoint now accepts `limit` and `offset` query parameters
- Passes pagination parameters to `UserManager.getUsers()`

### Admin UI
- `/admin/users` page now implements pagination with configurable limit (default 25)
- Generates pager navigation with next/previous links
- Displays user count and current range (from/to)

### Template Updates
- Added email column to users table with mailto links
- Reorganized action buttons (login link moved before delete button)
- Added `compact` CSS class to narrow columns
- Integrated pager partial for navigation between pages
- Shows pager even when no users on current page if previous pages exist

### Testing
- Comprehensive test suite for `getUsers()` with pagination parameters
- Tests for `userCount()` excluding system users
- Integration tests for `/users` endpoint pagination
- E2E test verifying email column visibility in admin users list

https://claude.ai/code/session_01C1ZazCbS1TNSByNpDAyYny