### PR TITLE
Add sendEmail task handler for async email delivery

### DIFF
--- a/source/e2e/start_server.sh
+++ b/source/e2e/start_server.sh
@@ -7,9 +7,13 @@ trap 'rm -rf "$TMP"' EXIT INT TERM
 
 : "${ROOT_DIR:="$( cd "$( dirname "$0" )/../.." && pwd )"}"
 : "${FILES_DIR:="$TMP"}"
+# Swallow every email into the nodemailer json transport so e2e never
+# attempts a real SMTP connection. send.ts checks for this var.
+: "${MAIL_FAKE:=1}"
 
 export ROOT_DIR
 export FILES_DIR
+export MAIL_FAKE
 
 (
   set -e

--- a/source/e2e/tests/admin.spec.ts
+++ b/source/e2e/tests/admin.spec.ts
@@ -38,6 +38,45 @@ test("shows the email of users in the admin users list", async ({page, request})
   await expect(userRow.getByRole("link", {name: email})).toBeVisible();
 });
 
+test("schedules an onboarding email when send_onboarding is checked", async ({page})=>{
+  await page.goto("/ui/admin/users");
+  let name = `test-onboarding-${randomBytes(6).toString("base64url")}`;
+  let password = randomUUID();
+  let email = `${name}@example.com`;
+  await page.getByRole("button", {name: "labels.createUser"}).click();
+  const form = page.getByRole("dialog", {name: "labels.createUser"});
+  await expect(form).toBeVisible();
+  await form.getByRole("textbox", {name: "labels.username"}).fill(name);
+  await form.getByRole("textbox", {name: "password"}).fill(password);
+  await form.getByRole("textbox", {name: "email"}).fill(email);
+  await form.getByRole("checkbox", {name: "labels.sendOnboardingEmail"}).check();
+  await form.getByRole("button", {name: "buttons.submit"}).click();
+
+  // After form submit the page reloads on the users list. Now check the
+  // tasks list to confirm an onboarding sendEmail task was created.
+  await page.goto("/ui/admin/tasks?type=sendEmail&status=all");
+  const row = page.getByRole("row", {name: new RegExp(name)});
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("sendEmail");
+});
+
+test("does not schedule an onboarding email when the checkbox is not ticked", async ({page, request})=>{
+  let name = `test-no-onboarding-${randomBytes(6).toString("base64url")}`;
+  // Plain JSON POST without send_onboarding -> no task.
+  let res = await request.post("/users", {
+    data: {
+      username: name,
+      email: `${name}@example.com`,
+      password: randomUUID(),
+      level: "use",
+    },
+  });
+  await expect(res).toBeOK();
+
+  await page.goto("/ui/admin/tasks?type=sendEmail&status=all");
+  await expect(page.getByRole("row", {name: new RegExp(name)})).toHaveCount(0);
+});
+
 test("can delete a non-admin user", async ({page, request})=>{
   let username = `test-deleteuser-${randomBytes(6).toString("base64url")}`;
   let u = {

--- a/source/server/routes/admin/mail/sendtest.ts
+++ b/source/server/routes/admin/mail/sendtest.ts
@@ -1,11 +1,11 @@
 import { Request, Response } from "express";
-import sendmail from "../../../utils/mails/send.js";
-import { getLocals, getUser, useTemplateProperties  } from "../../../utils/locals.js";
+import { getLocals, getTaskScheduler, getUser, useTemplateProperties  } from "../../../utils/locals.js";
 import { BadRequestError } from "../../../utils/errors.js";
+import { sendEmail } from "../../../tasks/handlers/sendEmail.js";
 
 /**
  * Send a test email
- * Exposes all possible logs from the emailer
+ * Dispatched as a task so failures and SMTP logs are observable via the tasks UI.
  * This is a protected route and requires admin privileges
  */
 export default async function handleMailtest(req :Request, res :Response){
@@ -33,10 +33,15 @@ export default async function handleMailtest(req :Request, res :Response){
     return;
   }
 
-  let out = await sendmail({
-    to, 
-    subject: (config.get("brand") || "eCorpus")+" test email", 
-    html: mail_content
+  const taskScheduler = getTaskScheduler(req);
+  const out = await taskScheduler.run({
+    handler: sendEmail,
+    user_id: user?.uid ?? null,
+    data: {
+      to,
+      subject: (config.get("brand") || "eCorpus")+" test email",
+      html: mail_content,
+    },
   });
 
   res.status(200).send(out);

--- a/source/server/routes/auth/login.ts
+++ b/source/server/routes/auth/login.ts
@@ -2,8 +2,8 @@ import { createHmac } from "crypto";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 import User, { SafeUser } from "../../auth/User.js";
 import { BadRequestError, ForbiddenError, HTTPError, NotFoundError, UnauthorizedError } from "../../utils/errors.js";
-import { AppLocals, getHost, getLocals, getSession, getUser, getUserManager, validateRedirect, useTemplateProperties  } from "../../utils/locals.js";
-import sendmail from "../../utils/mails/send.js";
+import { AppLocals, getHost, getLocals, getSession, getTaskScheduler, getUser, getUserManager, validateRedirect, useTemplateProperties  } from "../../utils/locals.js";
+import { sendEmail } from "../../tasks/handlers/sendEmail.js";
 
 /**
  * Handler for login flow. Used for automated AND interactive login flows, which makes it a bit more complicated
@@ -208,6 +208,7 @@ export async function sendLoginLink(req :Request, res :Response){
   let {sessionMaxAge} = getLocals(req);
   let {username} = req.params;
   let userManager = getUserManager(req);
+  let taskScheduler = getTaskScheduler(req);
 
   let user = await userManager.getUserByName(username);
   if(!user.email){
@@ -216,7 +217,7 @@ export async function sendLoginLink(req :Request, res :Response){
   let key = (await userManager.getKeys())[0];
   let link = makeRedirect(
     key,
-    {user, expiresIn: sessionMaxAge, redirect: getHost(req)}, 
+    {user, expiresIn: sessionMaxAge, redirect: getHost(req)},
   );
 
   let lang = "fr";
@@ -226,12 +227,16 @@ export async function sendLoginLink(req :Request, res :Response){
     lang: "fr",
     url: link.toString()
   });
-  await sendmail({
-    to: user.email,
-    subject: "Votre lien de connexion à eCorpus",
-    html: mail_content,
-  });
-  
-  console.log("sent an account recovery mail to :", user.email);
+  //Don't await delivery: the task is persisted and logs are observable via the tasks UI
+  taskScheduler.run({
+    handler: sendEmail,
+    user_id: user.uid,
+    data: {
+      to: user.email,
+      subject: "Votre lien de connexion à eCorpus",
+      html: mail_content,
+    },
+  }).catch(err => console.error(`sendLoginLink to ${user.email} failed:`, err));
+
   res.status(204).send();
 }

--- a/source/server/routes/users/post.ts
+++ b/source/server/routes/users/post.ts
@@ -1,22 +1,33 @@
 
 import { Request, Response } from "express";
 
-import { getUserManager } from "../../utils/locals.js";
-import User, { isUserRole, UserRoles } from "../../auth/User.js";
+import { getHost, getLocals, getTaskScheduler, getUserManager } from "../../utils/locals.js";
+import User, { isUserRole } from "../../auth/User.js";
 import UserManager from "../../auth/UserManager.js";
 import { BadRequestError } from "../../utils/errors.js";
+import { makeRedirect } from "../auth/login.js";
+import { sendEmail } from "../../tasks/handlers/sendEmail.js";
+import { AcceptedLocales, dicts } from "../../utils/templates/index.js";
 
 
+function pickLang(value: any): AcceptedLocales {
+  return (dicts as readonly string[]).includes(value) ? value : "en";
+}
 
 
 export default async function postUser(req :Request, res :Response){
   let userManager :UserManager = getUserManager(req);
-  let {username, password, email, level = "create"} = req.body;
+  let {username, password, email, level = "create", lang, send_onboarding} = req.body;
   if(!username) throw new BadRequestError("username not provided");
   if(!password) throw new BadRequestError("password not provided");
   if(!isUserRole(level)) throw new BadRequestError("bad value for user level");
   if(!email) throw new BadRequestError("email not provided");
   let u = await userManager.addUser(username, password, level, email);
+
+  if(send_onboarding){
+    await dispatchOnboardingEmail(req, u, pickLang(lang));
+  }
+
   res.format({
     "application/json": ()=>{
       res.status(201).send(User.safe(u));
@@ -28,7 +39,7 @@ export default async function postUser(req :Request, res :Response){
           return res.redirect(303, referrer.toString());
         }
       }
-        
+
       return res.status(201).send(`Created user ${u.username} <${u.email}>: ${u.level}`);
 
     },
@@ -37,3 +48,40 @@ export default async function postUser(req :Request, res :Response){
     }
   });
 };
+
+
+/**
+ * Render the onboarding email and schedule it as a `sendEmail` task.
+ * Delivery runs in the background so user creation is not blocked by SMTP.
+ */
+async function dispatchOnboardingEmail(req: Request, user: User, lang: AcceptedLocales){
+  if(!user.email) return;
+  const {sessionMaxAge, templates, config} = getLocals(req);
+  const userManager = getUserManager(req);
+  const taskScheduler = getTaskScheduler(req);
+
+  const key = (await userManager.getKeys())[0];
+  const link = makeRedirect(key, {
+    user,
+    expiresIn: sessionMaxAge,
+    redirect: getHost(req),
+  });
+
+  const brand = config.get("brand") || "eCorpus";
+  const html = await templates.render(`emails/onboarding_${lang}`, {
+    layout: null,
+    lang,
+    name: user.username,
+    url: link.toString(),
+    brand,
+    hostname: config.get("hostname"),
+  });
+
+  const subject = lang === "fr" ? `Bienvenue sur ${brand}` : `Welcome to ${brand}`;
+
+  taskScheduler.run({
+    handler: sendEmail,
+    user_id: user.uid,
+    data: { to: user.email, subject, html },
+  }).catch(err => console.error(`Onboarding email to ${user.email} failed:`, err));
+}

--- a/source/server/routes/users/post.ts
+++ b/source/server/routes/users/post.ts
@@ -14,6 +14,17 @@ function pickLang(value: any): AcceptedLocales {
   return (dicts as readonly string[]).includes(value) ? value : "en";
 }
 
+/**
+ * Accept JSON booleans (`true`/`false`) and form values (`"on"`, `"true"`, `"1"`).
+ * Anything else &mdash; including the literal strings `"false"`, `"0"` or `""` &mdash;
+ * is treated as opt-out.
+ */
+function isTruthyFlag(value: any): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return /^(on|true|1|yes)$/i.test(value);
+  return false;
+}
+
 
 export default async function postUser(req :Request, res :Response){
   let userManager :UserManager = getUserManager(req);
@@ -24,7 +35,7 @@ export default async function postUser(req :Request, res :Response){
   if(!email) throw new BadRequestError("email not provided");
   let u = await userManager.addUser(username, password, level, email);
 
-  if(send_onboarding){
+  if(isTruthyFlag(send_onboarding)){
     await dispatchOnboardingEmail(req, u, pickLang(lang));
   }
 
@@ -52,7 +63,10 @@ export default async function postUser(req :Request, res :Response){
 
 /**
  * Render the onboarding email and schedule it as a `sendEmail` task.
- * Delivery runs in the background so user creation is not blocked by SMTP.
+ *
+ * The task row is `create()`d (and awaited) before this function returns so
+ * callers can observe the task immediately. Delivery itself runs in the
+ * background and any failure is logged to the task row, not bubbled up.
  */
 async function dispatchOnboardingEmail(req: Request, user: User, lang: AcceptedLocales){
   if(!user.email) return;
@@ -79,9 +93,14 @@ async function dispatchOnboardingEmail(req: Request, user: User, lang: AcceptedL
 
   const subject = lang === "fr" ? `Bienvenue sur ${brand}` : `Welcome to ${brand}`;
 
-  taskScheduler.run({
-    handler: sendEmail,
+  // Commit the task row first so it is observable as soon as the user
+  // creation request returns, then dispatch the run without awaiting.
+  const task = await taskScheduler.create({
+    type: sendEmail.name,
+    status: "pending",
     user_id: user.uid,
     data: { to: user.email, subject, html },
-  }).catch(err => console.error(`Onboarding email to ${user.email} failed:`, err));
+  });
+  taskScheduler.runTask({ task, handler: sendEmail })
+    .catch(err => console.error(`Onboarding email to ${user.email} failed:`, err));
 }

--- a/source/server/tasks/handlers/index.ts
+++ b/source/server/tasks/handlers/index.ts
@@ -11,3 +11,5 @@ export {
   optimize,
   runCleanup,
 } from "./cleanup.js";
+
+export {sendEmail} from "./sendEmail.js";

--- a/source/server/tasks/handlers/sendEmail.test.ts
+++ b/source/server/tasks/handlers/sendEmail.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import nodemailer from "nodemailer";
+
+import openDatabase, { Database } from "../../vfs/helpers/db.js";
+import Vfs from "../../vfs/index.js";
+import UserManager from "../../auth/UserManager.js";
+import { Config } from "../../utils/config.js";
+import { TaskScheduler } from "../scheduler.js";
+import { setTransporter } from "../../utils/mails/send.js";
+import { sendEmail } from "./sendEmail.js";
+
+
+describe("sendEmail task handler", function () {
+  let db_uri: string, handle: Database;
+  let scheduler: TaskScheduler;
+  let vfs: Vfs;
+  let config: Config;
+  let rootDir: string;
+
+  this.beforeAll(async function () {
+    db_uri = await getUniqueDb("ecorpus_sendmail_handler");
+    handle = await openDatabase({ uri: db_uri });
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "ecorpus-sendmail-"));
+    vfs = await Vfs.Open(rootDir, { db: handle, forceMigration: false });
+    config = await Config.open(handle, {});
+  });
+
+  this.afterAll(async function () {
+    Config.close();
+    await handle?.end();
+    if (rootDir) await fs.rm(rootDir, { recursive: true, force: true });
+    if (db_uri) await dropDb(db_uri);
+    setTransporter(undefined);
+  });
+
+  this.beforeEach(async function () {
+    const userManager = new UserManager(handle);
+    scheduler = new TaskScheduler({ db: handle, vfs, userManager, config });
+  });
+
+  this.afterEach(async function () {
+    await handle.run(`DELETE FROM tasks_logs`);
+    await handle.run(`DELETE FROM tasks`);
+    if (!scheduler.closed) await scheduler.close();
+    setTransporter(undefined);
+  });
+
+  it("delivers the email and resolves to SMTP info", async function () {
+    setTransporter(nodemailer.createTransport({ jsonTransport: true }));
+
+    const out = await scheduler.run({
+      handler: sendEmail,
+      data: {
+        to: "alice@example.com",
+        subject: "Hello",
+        html: "<p>Hi</p>",
+      },
+    });
+
+    expect(out).to.have.property("accepted").that.deep.equals(["alice@example.com"]);
+    expect(out).to.have.property("messageId").a("string");
+  });
+
+  it("records the task as success with persisted log lines", async function () {
+    setTransporter(nodemailer.createTransport({ jsonTransport: true }));
+
+    await scheduler.run({
+      handler: sendEmail,
+      data: { to: "bob@example.com", subject: "Hi", html: "<p>hello</p>" },
+    });
+
+    const tasks = await scheduler.getTasks({ type: "sendEmail", status: "success" });
+    expect(tasks).to.have.length.at.least(1);
+    const last = tasks[0];
+    expect(last).to.have.property("status", "success");
+
+    const logs = await scheduler.getLogs(last.task_id);
+    const messages = logs.map(l => l.message);
+    expect(messages.some(m => /Sending email to bob@example.com/.test(m)),
+      `expected a "Sending email" log line, got: ${messages.join(" | ")}`).to.equal(true);
+    expect(messages.some(m => /Delivered to bob@example.com/.test(m)),
+      `expected a "Delivered to" log line, got: ${messages.join(" | ")}`).to.equal(true);
+  });
+
+  it("marks the task as error when SMTP fails", async function () {
+    const failing = {
+      sendMail: async () => { throw new Error("boom"); },
+    } as unknown as nodemailer.Transporter;
+    setTransporter(failing);
+
+    await expect(scheduler.run({
+      handler: sendEmail,
+      data: { to: "carol@example.com", subject: "Hi", html: "<p>hello</p>" },
+    })).to.be.rejectedWith(/boom/);
+
+    const tasks = await scheduler.getTasks({ type: "sendEmail", status: "error" });
+    expect(tasks).to.have.length.at.least(1);
+    expect(tasks[0]).to.have.property("status", "error");
+  });
+});

--- a/source/server/tasks/handlers/sendEmail.ts
+++ b/source/server/tasks/handlers/sendEmail.ts
@@ -1,0 +1,43 @@
+import sendmail from "../../utils/mails/send.js";
+import { TaskHandlerParams } from "../types.js";
+
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+}
+
+export interface SendEmailResult {
+  messageId?: string;
+  accepted?: string[];
+  rejected?: string[];
+  response?: string;
+}
+
+/**
+ * Send an email through the configured SMTP transport.
+ *
+ * Wrapping {@link sendmail} in a task gives us a persisted log line per
+ * delivery attempt and lets callers observe failures through the standard
+ * tasks UI/API instead of having to scrape the server logs.
+ */
+export async function sendEmail({ task: { data }, context: { logger } }: TaskHandlerParams<SendEmailParams>): Promise<SendEmailResult> {
+  const { to, subject } = data;
+  logger.log(`Sending email to ${to} (subject: ${subject})`);
+  const info = await sendmail({
+    to: data.to,
+    subject: data.subject,
+    html: data.html,
+    text: data.text,
+  });
+  logger.log(`Delivered to ${(info.accepted ?? []).join(", ") || "<none>"}${info.rejected?.length ? `, rejected: ${info.rejected.join(", ")}` : ""}`);
+  if (info.messageId) logger.debug(`messageId: ${info.messageId}`);
+  return {
+    messageId: info.messageId,
+    accepted: info.accepted as string[] | undefined,
+    rejected: info.rejected as string[] | undefined,
+    response: (info as any).response,
+  };
+}

--- a/source/server/tasks/handlers/sendEmail.ts
+++ b/source/server/tasks/handlers/sendEmail.ts
@@ -11,8 +11,13 @@ export interface SendEmailParams {
 
 export interface SendEmailResult {
   messageId?: string;
-  accepted?: string[];
-  rejected?: string[];
+  /**
+   * Effective recipient list as seen by the transport. For SMTP transports
+   * this is `info.accepted`; for in-memory transports (e.g. nodemailer's
+   * jsonTransport used in tests) we fall back to the envelope.
+   */
+  accepted: string[];
+  rejected: string[];
   response?: string;
 }
 
@@ -32,12 +37,20 @@ export async function sendEmail({ task: { data }, context: { logger } }: TaskHan
     html: data.html,
     text: data.text,
   });
-  logger.log(`Delivered to ${(info.accepted ?? []).join(", ") || "<none>"}${info.rejected?.length ? `, rejected: ${info.rejected.join(", ")}` : ""}`);
+  // Not every nodemailer transport populates `accepted` (jsonTransport for
+  // instance only reports `envelope`). Normalize so callers always have a list.
+  const envelopeTo = ((info as any).envelope?.to ?? []) as string[];
+  const accepted = ((info.accepted ?? envelopeTo) as Array<string|{address:string}>)
+    .map(a => typeof a === "string" ? a : a.address);
+  const rejected = ((info.rejected ?? []) as Array<string|{address:string}>)
+    .map(a => typeof a === "string" ? a : a.address);
+
+  logger.log(`Delivered to ${accepted.join(", ") || "<none>"}${rejected.length ? `, rejected: ${rejected.join(", ")}` : ""}`);
   if (info.messageId) logger.debug(`messageId: ${info.messageId}`);
   return {
     messageId: info.messageId,
-    accepted: info.accepted as string[] | undefined,
-    rejected: info.rejected as string[] | undefined,
+    accepted,
+    rejected,
     response: (info as any).response,
   };
 }

--- a/source/server/templates/admin/users.hbs
+++ b/source/server/templates/admin/users.hbs
@@ -133,6 +133,10 @@
         <option value="admin">{{i18n "fields.userRoles.admin"}}</option>
       </select>
     </div>
+    <div class="form-item" style="display:flex; flex-direction:row-reverse; justify-content:flex-end; align-items:center; gap:.5rem;">
+      <label for="send_onboarding">{{i18n "labels.sendOnboardingEmail"}}</label>
+      <input type="checkbox" name="send_onboarding" id="send_onboarding" value="on">
+    </div>
     <div class="form-item" style="margin-top: 15px">
       <input class="btn" type="submit" value="{{i18n "buttons.submit"}}" >
     </div>

--- a/source/server/templates/emails/onboarding_en.hbs
+++ b/source/server/templates/emails/onboarding_en.hbs
@@ -1,0 +1,48 @@
+<h1 style="display: inline-block; padding: 1.5rem 0.2rem 0 1.5rem; border-bottom: 0.6rem solid #E6B900;">Welcome to {{brand}}</h1>
+
+<p>Hi <b>{{name}}</b>,</p>
+<p>
+  An account has been created for you on
+  <a href="https://{{hostname}}/">{{hostname}}</a>.
+  Click the button below to sign in &mdash; no password required:
+</p>
+
+<p style="text-align: center; padding: 1rem;">
+  <a style="color: white; background: #E6B900; border-radius: 2px; padding: 1rem 1.5rem; font-size: large; text-decoration: none!important;" href="{{url}}">Sign in</a>
+</p>
+
+<p>If the button doesn't work, paste this link into your browser address bar:</p>
+
+<p><a href="{{url}}">{{url}}</a></p>
+
+<p>
+  Once signed in, head over to <b>User Settings</b> to set a password so you can
+  log in again later.
+</p>
+
+<h2 style="border-left: 0.7rem solid #E6B900; padding: 0.5rem 0 0 0.8rem;">Getting started</h2>
+<ul>
+  <li>
+    <b>Import a scene</b> &mdash; upload a 3D model or a Voyager archive from
+    your dashboard. See the
+    <a href="https://ecorpus.eu/en/doc/tutorials/import/">import tutorial</a>.
+  </li>
+  <li>
+    <b>Annotate and tell a story</b> &mdash; open the scene in Voyager Story to
+    add articles, tours and annotations. See the
+    <a href="https://ecorpus.eu/en/doc/tutorials/annotate/">annotation tutorial</a>.
+  </li>
+  <li>
+    <b>Publish and embed</b> &mdash; manage access rights and embed the viewer
+    on your website. See the
+    <a href="https://ecorpus.eu/en/doc/tutorials/embed/">publishing tutorial</a>.
+  </li>
+</ul>
+
+<p>
+  For more, browse the full documentation at
+  <a href="https://ecorpus.eu/en/doc/">ecorpus.eu/en/doc</a>.
+  If you run into trouble, please contact your instance administrator.
+</p>
+
+<p>Have fun building your corpus!</p>

--- a/source/server/templates/emails/onboarding_fr.hbs
+++ b/source/server/templates/emails/onboarding_fr.hbs
@@ -1,0 +1,48 @@
+<h1 style="display: inline-block; padding: 1.5rem 0.2rem 0 1.5rem; border-bottom: 0.6rem solid #E6B900;">Bienvenue sur {{brand}}</h1>
+
+<p>Bonjour <b>{{name}}</b>,</p>
+<p>
+  Un compte vient d'être créé pour vous sur
+  <a href="https://{{hostname}}/">{{hostname}}</a>.
+  Cliquez sur le bouton ci-dessous pour vous connecter &mdash; aucun mot de passe nécessaire :
+</p>
+
+<p style="text-align: center; padding: 1rem;">
+  <a style="color: white; background: #E6B900; border-radius: 2px; padding: 1rem 1.5rem; font-size: large; text-decoration: none!important;" href="{{url}}">Se connecter</a>
+</p>
+
+<p>Si le bouton ne fonctionne pas, copiez-collez ce lien dans la barre d'adresse de votre navigateur :</p>
+
+<p><a href="{{url}}">{{url}}</a></p>
+
+<p>
+  Une fois connecté(e), rendez-vous dans les <b>paramètres utilisateur</b> pour
+  définir un mot de passe et pouvoir vous reconnecter par la suite.
+</p>
+
+<h2 style="border-left: 0.7rem solid #E6B900; padding: 0.5rem 0 0 0.8rem;">Pour bien démarrer</h2>
+<ul>
+  <li>
+    <b>Importer une scène</b> &mdash; téléversez un modèle 3D ou une archive
+    Voyager depuis votre tableau de bord. Voir le
+    <a href="https://ecorpus.eu/fr/doc/tutorials/import/">tutoriel d'import</a>.
+  </li>
+  <li>
+    <b>Annoter et raconter</b> &mdash; ouvrez la scène dans Voyager Story pour
+    ajouter articles, visites et annotations. Voir le
+    <a href="https://ecorpus.eu/fr/doc/tutorials/annotate/">tutoriel d'annotation</a>.
+  </li>
+  <li>
+    <b>Publier et intégrer</b> &mdash; gérez les droits d'accès et intégrez le
+    visualiseur sur votre site. Voir le
+    <a href="https://ecorpus.eu/fr/doc/tutorials/embed/">tutoriel de publication</a>.
+  </li>
+</ul>
+
+<p>
+  Pour aller plus loin, consultez la documentation complète sur
+  <a href="https://ecorpus.eu/fr/doc/">ecorpus.eu/fr/doc</a>.
+  En cas de problème, contactez l'administrateur de votre instance.
+</p>
+
+<p>Bonne aventure avec votre corpus&nbsp;!</p>

--- a/source/server/templates/locales/en.yml
+++ b/source/server/templates/locales/en.yml
@@ -26,6 +26,7 @@ labels:
   sortBy: Sort by
   loginLink: Copy direct login link
   sendLoginLink: Send a login link
+  sendOnboardingEmail: Send onboarding email
   view: View
   edit: Edit
   editDefault: Edit (value is unchanged from default)

--- a/source/server/templates/locales/fr.yml
+++ b/source/server/templates/locales/fr.yml
@@ -26,6 +26,7 @@ labels:
   sortBy: Trier par
   loginLink: Copier un lien de connexion
   sendLoginLink: Envoyer un lien
+  sendOnboardingEmail: Envoyer un email de bienvenue
   view: Voir
   edit: Editer
   editDefault: Editer (valeur par défaut)

--- a/source/server/tests-common.ts
+++ b/source/server/tests-common.ts
@@ -16,6 +16,9 @@ sourceMaps.install();
 chai.use(chaiAsPromised);
 
 process.env["TEST"] ??= "true";
+// Force every test run to use the in-memory nodemailer json transport so no
+// SMTP connection is ever attempted from a test.
+process.env["MAIL_FAKE"] ??= "true";
 
 const debug = debuglog("pg:debug");
 

--- a/source/server/utils/mails/send.ts
+++ b/source/server/utils/mails/send.ts
@@ -39,11 +39,17 @@ export default async function send(
   transporter?: nodemailer.Transporter,
 ) :ReturnType<nodemailer.Transporter["sendMail"]>{
   if(!transporter && !_transporter){
-    let transportURL = new URL(Config.get("smart_host"));
-    //Set logger to the value of VERBOSE env var
-    if(!transportURL.searchParams.has("logger")) transportURL.searchParams.set("logger", Config.get("verbose")? "true": "false");
-    if(!transportURL.searchParams.has("name")) transportURL.searchParams.set("name", Config.get("hostname"));
-    _transporter = nodemailer.createTransport(transportURL.toString())
+    if(process.env["MAIL_FAKE"]){
+      //Test / e2e mode: swallow every message into the in-memory JSON transport
+      //so deliveries never hit a real SMTP server.
+      _transporter = nodemailer.createTransport({ jsonTransport: true });
+    } else {
+      let transportURL = new URL(Config.get("smart_host"));
+      //Set logger to the value of VERBOSE env var
+      if(!transportURL.searchParams.has("logger")) transportURL.searchParams.set("logger", Config.get("verbose")? "true": "false");
+      if(!transportURL.searchParams.has("name")) transportURL.searchParams.set("name", Config.get("hostname"));
+      _transporter = nodemailer.createTransport(transportURL.toString())
+    }
   }
 
   transporter ??= _transporter;

--- a/source/server/utils/mails/send.ts
+++ b/source/server/utils/mails/send.ts
@@ -16,16 +16,23 @@ interface MailInput{
 /**
  * Use smart host string with defaults
  */
-let _transporter: nodemailer.Transporter;
+let _transporter: nodemailer.Transporter|undefined;
+
+/**
+ * Override the cached SMTP transporter. Pass `undefined` to fall back to the
+ * smart_host configuration the next time `send()` is called. Intended for tests.
+ */
+export function setTransporter(t: nodemailer.Transporter|undefined){
+  _transporter = t;
+}
 
 
 /**
- * use sendmail to send an email
- * **sendmail** is not really required but using /usr/bin/sendmail is not cross-platform and requires more configuration
- * @param sender should only be changed in tests
+ * Low-level SMTP send. Almost all callers should go through the
+ * `sendEmail` task handler instead so failures show up in the tasks UI
+ * and a log line is persisted per delivery attempt.
+ * @param transporter should only be changed in tests
  * @see {Templates} to write emails
- * 
- * @deprecated should be in a task
  */
 export default async function send(
   message :MailInput,
@@ -40,6 +47,7 @@ export default async function send(
   }
 
   transporter ??= _transporter;
+  if(!transporter) throw new Error("Mail transporter is not initialized");
 
   const info = await transporter.sendMail({
     from: Config.get("contact_email"),


### PR DESCRIPTION
## Summary
Refactors email delivery to use the task scheduler system, enabling asynchronous email sending with persistent logging and observable failure tracking through the tasks UI.

## Key Changes

- **New `sendEmail` task handler** (`source/server/tasks/handlers/sendEmail.ts`): Wraps the low-level SMTP send function to provide task-based email delivery with structured logging of delivery attempts and results.

- **Updated email dispatch points**: Modified three routes to use the task scheduler instead of direct SMTP calls:
  - User creation (`POST /users`) now optionally sends onboarding emails
  - Login link requests (`sendLoginLink`) dispatch password reset emails asynchronously
  - Admin test email endpoint dispatches test emails as tasks

- **New onboarding email templates**: Added bilingual onboarding email templates (`onboarding_en.hbs`, `onboarding_fr.hbs`) with getting-started guidance and magic link authentication.

- **Enhanced user creation endpoint**: Extended `POST /users` to accept `lang` and `send_onboarding` parameters, allowing callers to trigger welcome emails in the user's preferred language.

- **Improved mail transporter management** (`source/server/utils/mails/send.ts`): Added `setTransporter()` export for test injection and clarified that direct `send()` calls should be avoided in favor of the task handler.

- **Comprehensive test coverage** (`sendEmail.test.ts`): Added tests verifying successful delivery, task logging, and error handling.

## Implementation Details

- Email delivery is non-blocking: tasks are scheduled but not awaited, allowing user creation and login flows to complete immediately while emails are sent in the background.
- All email delivery attempts are logged persistently and observable via the tasks API/UI, replacing the need to scrape server logs for delivery failures.
- The task handler returns SMTP metadata (messageId, accepted/rejected recipients) for caller inspection.
- Onboarding emails include magic link authentication and contextual getting-started resources.

https://claude.ai/code/session_01MHsjKDZEcdTampB4Bbp9Xm