### PR TITLE
Add user search functionality to admin users page

### DIFF
--- a/source/server/templates/admin/users.hbs
+++ b/source/server/templates/admin/users.hbs
@@ -9,6 +9,15 @@
   {{/if}}
 </div>
 
+<form class="form-control" method="GET" action="/ui/admin/users" style="padding-bottom: 1rem;">
+  <div class="form-item">
+    <input class="search-box-input" type="search" name="match" id="user-search" aria-label="{{i18n "titles.search"}}" placeholder="{{i18n "labels.searchUserPlaceholder"}}"
+      value="{{params.match}}">
+    <button class="btn btn-main" style="margin-top:0" type="submit" aria-label="{{i18n "titles.search"}}"><ui-icon
+        name="search"></ui-icon></button>
+  </div>
+</form>
+
 <div class="list-table-wrap users-list flush" style="position:relative;">
   <style>
     .users-list table.list-table td.col-name,
@@ -96,6 +105,8 @@
     {{#with pager}}
       {{> pager }}
     {{/with}}
+  {{else if params.match}}
+    <div style="text-align: center;">{{i18n "leads.noResults"}}</div>
   {{else}}
     <div style="text-align: center;">No user registered. Click the <ui-icon name="plus"></ui-icon> to add one</div>
   {{/if}}

--- a/source/server/templates/locales/en.yml
+++ b/source/server/templates/locales/en.yml
@@ -23,6 +23,7 @@ labels:
   forgottenPassword: Forgotten password
   pagination: pagination
   searchPlaceholder: search a scene
+  searchUserPlaceholder: search by name or email
   ignoredIfMultipleScenes: ignored if multiple scenes are created at the same time
   sortBy: Sort by
   loginLink: Copy direct login link

--- a/source/server/templates/locales/fr.yml
+++ b/source/server/templates/locales/fr.yml
@@ -23,6 +23,7 @@ labels:
   forgottenPassword: Mot de passe oublié?
   pagination: pagination
   searchPlaceholder: chercher une scène
+  searchUserPlaceholder: chercher par nom ou email
   ignoredIfMultipleScenes: ignoré si plusieurs scènes sont créées simultanément
   sortBy: Trier par
   loginLink: Copier un lien de connexion


### PR DESCRIPTION
## Summary
Added a search feature to the admin users management page, allowing administrators to filter users by name or email.

## Key Changes
- Added a search form with input field and submit button to the users admin template
- Implemented GET-based search with `match` parameter sent to `/ui/admin/users`
- Added conditional rendering to display "no results" message when search yields no users
- Added localization strings for search placeholder in both English and French:
  - `searchUserPlaceholder: search by name or email` (EN)
  - `searchUserPlaceholder: chercher par nom ou email` (FR)

## Implementation Details
- The search form uses a GET method to maintain stateless filtering
- The search input preserves the current search value using `{{params.match}}`
- Search results handling distinguishes between "no results from search" and "no users registered" states
- Follows existing UI patterns with consistent styling and accessibility attributes (aria-labels)

https://claude.ai/code/session_01UVrmvdPDeAw9C6FBQTn3Uk